### PR TITLE
docs: repoint install/metadata URLs to intersystems-ib

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "iris-interop-skills",
   "owner": {
     "name": "Pierre-Yves Duquesnoy",
-    "url": "https://github.com/PYDuquesnoy"
+    "url": "https://github.com/intersystems-ib"
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,9 +4,9 @@
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 6 hooks (SessionStart conventions bootstrap + a PreToolUse conformance gate that blocks non-conformant writes and class loads/compiles smuggled through iris_execute + 4 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",
-    "url": "https://github.com/PYDuquesnoy"
+    "url": "https://github.com/intersystems-ib"
   },
-  "homepage": "https://github.com/PYDuquesnoy/iris-interop-skills",
+  "homepage": "https://github.com/intersystems-ib/iris-interop-skills",
   "license": "MIT",
   "keywords": [
     "iris",

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ self-contained binary.
 1. **Add the marketplace + install the plugin:**
 
    ```text
-   /plugin marketplace add PYDuquesnoy/iris-interop-skills
+   /plugin marketplace add intersystems-ib/iris-interop-skills
    /plugin install iris-interop-skills@iris-interop-skills
    ```
 

--- a/skills/report-issue/SKILL.md
+++ b/skills/report-issue/SKILL.md
@@ -31,7 +31,7 @@ correctly reported it), it is **not** reportable.
 | Problem | Default target |
 |---|---|
 | MCP tool defect | the IRIS MCP repo (`intersystems-community/iris-agentic-dev`, or the fork in use) |
-| Skill content / routing / hook | the skills repo (`PYDuquesnoy/iris-interop-skills`) |
+| Skill content / routing / hook | the skills repo (`intersystems-ib/iris-interop-skills`) |
 | Workshop exercise / material | the workshop repo |
 
 Confirm the target with the user if unsure. Requires the GitHub CLI (`gh`) authenticated in the session.


### PR DESCRIPTION
Naming fixes now that the plugin lives under **intersystems-ib**.

- `README.md` — `/plugin marketplace add` → `intersystems-ib/iris-interop-skills`
- `.claude-plugin/plugin.json` — `homepage` + `author.url` → intersystems-ib
- `.claude-plugin/marketplace.json` — `owner.url` → intersystems-ib
- `skills/report-issue/SKILL.md` — default issue target → `intersystems-ib/iris-interop-skills`

Intentionally left unchanged: the community upstream `intersystems-community/iris-agentic-dev` binary/brew/releases refs, and the separate open-source `PYDuquesnoy/IRIS-Interop-Deployment` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)