### PR TITLE
Reject a python3 that resolves but does not run

### DIFF
--- a/hooks/conformance-prescan.sh
+++ b/hooks/conformance-prescan.sh
@@ -3,8 +3,19 @@
 # .cls is written, cheaply screen that file for the mechanically-detectable anti-patterns
 # (CR-1/2/4/5/7/10) and, if any match, nudge to run the conformance-reviewer agent. Thin
 # wrapper: exec the .py so the hook JSON on stdin reaches Python. Resolves the interpreter
-# as python3 -> python -> py (Windows has no `python3`); no-op if none is on PATH. Never blocks.
-PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || command -v py 2>/dev/null)
+# as python3 -> python -> py (Windows has no real `python3`, only a Store stub that must be rejected); no-op if none is on PATH. Never blocks.
+PY=
+for _cand in python3 python py; do
+    _path=$(command -v "$_cand" 2>/dev/null) || continue
+    # Being on PATH is not the same as working. Windows ships a 0-byte Microsoft Store
+    # stub named python3.exe in %LOCALAPPDATA%\Microsoft\WindowsApps: `command -v` finds
+    # it, exec'ing it prints "Python was not found" and exits non-zero. Taking the first
+    # name that resolves made every hook fail on a machine that had a perfectly good
+    # python.exe one PATH entry away. Run the candidate before trusting it.
+    "$_path" -c '' >/dev/null 2>&1 || continue
+    PY=$_path
+    break
+done
 [ -n "$PY" ] || exit 0
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 exec "$PY" "$DIR/conformance_prescan.py"

--- a/hooks/docker-detect.sh
+++ b/hooks/docker-detect.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 # PostToolUse non-Docker hint (iris-interop-skills, C4) — on a DOCKER_REQUIRED error, advise the
 # HTTP path. Thin wrapper so the hook JSON on stdin reaches Python. Resolves the interpreter as
-# python3 -> python -> py (Windows has no `python3`); no-op if none is on PATH.
-PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || command -v py 2>/dev/null)
+# python3 -> python -> py (Windows has no real `python3`, only a Store stub that must be rejected); no-op if none is on PATH.
+PY=
+for _cand in python3 python py; do
+    _path=$(command -v "$_cand" 2>/dev/null) || continue
+    # Being on PATH is not the same as working. Windows ships a 0-byte Microsoft Store
+    # stub named python3.exe in %LOCALAPPDATA%\Microsoft\WindowsApps: `command -v` finds
+    # it, exec'ing it prints "Python was not found" and exits non-zero. Taking the first
+    # name that resolves made every hook fail on a machine that had a perfectly good
+    # python.exe one PATH entry away. Run the candidate before trusting it.
+    "$_path" -c '' >/dev/null 2>&1 || continue
+    PY=$_path
+    break
+done
 [ -n "$PY" ] || exit 0
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 exec "$PY" "$DIR/docker_detect.py"

--- a/hooks/interop-bootstrap.sh
+++ b/hooks/interop-bootstrap.sh
@@ -1,8 +1,19 @@
 #!/bin/sh
 # SessionStart bootstrap (iris-interop-skills) — inject the core interop conventions up front so a weak
 # model has them without needing to call the Skill tool. Thin wrapper: exec the .py. Resolves
-# python3 -> python -> py (Windows has no `python3`); exit 0 (no injection) if none is on PATH.
-PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || command -v py 2>/dev/null)
+# python3 -> python -> py (Windows has no real `python3`, only a Store stub that must be rejected); exit 0 (no injection) if none is on PATH.
+PY=
+for _cand in python3 python py; do
+    _path=$(command -v "$_cand" 2>/dev/null) || continue
+    # Being on PATH is not the same as working. Windows ships a 0-byte Microsoft Store
+    # stub named python3.exe in %LOCALAPPDATA%\Microsoft\WindowsApps: `command -v` finds
+    # it, exec'ing it prints "Python was not found" and exits non-zero. Taking the first
+    # name that resolves made every hook fail on a machine that had a perfectly good
+    # python.exe one PATH entry away. Run the candidate before trusting it.
+    "$_path" -c '' >/dev/null 2>&1 || continue
+    PY=$_path
+    break
+done
 [ -n "$PY" ] || exit 0
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 exec "$PY" "$DIR/interop_bootstrap.py"

--- a/hooks/interop-conformance-gate.sh
+++ b/hooks/interop-conformance-gate.sh
@@ -2,9 +2,20 @@
 # PreToolUse conformance GATE for iris_doc|iris_compile (iris-interop-skills) — BLOCKS a write/compile
 # that violates a hard naming/superclass convention (non-standard .Tipo. segment, or a BS/BO that
 # extends the adapter directly), forcing a fix before the class lands. Thin wrapper: exec the .py so
-# the hook JSON on stdin reaches Python. Resolves python3 -> python -> py (Windows has no `python3`);
+# the hook JSON on stdin reaches Python. Resolves python3 -> python -> py (Windows has no real `python3`, only a Store stub that must be rejected);
 # if no interpreter is on PATH, exit 0 (allow) — never block legitimate work on a missing interpreter.
-PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || command -v py 2>/dev/null)
+PY=
+for _cand in python3 python py; do
+    _path=$(command -v "$_cand" 2>/dev/null) || continue
+    # Being on PATH is not the same as working. Windows ships a 0-byte Microsoft Store
+    # stub named python3.exe in %LOCALAPPDATA%\Microsoft\WindowsApps: `command -v` finds
+    # it, exec'ing it prints "Python was not found" and exits non-zero. Taking the first
+    # name that resolves made every hook fail on a machine that had a perfectly good
+    # python.exe one PATH entry away. Run the candidate before trusting it.
+    "$_path" -c '' >/dev/null 2>&1 || continue
+    PY=$_path
+    break
+done
 [ -n "$PY" ] || exit 0
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 exec "$PY" "$DIR/interop_conformance_gate.py"

--- a/hooks/silent-execute-guard.sh
+++ b/hooks/silent-execute-guard.sh
@@ -2,9 +2,20 @@
 # PostToolUse guard for iris_execute (iris-interop-skills) — advisory note when the
 # call succeeded but captured no output. Thin wrapper: exec the .py so the hook JSON
 # on stdin reaches Python (a heredoc would consume stdin instead). Resolves the
-# interpreter as python3 -> python -> py (Windows has no `python3`); no-op if none is
+# interpreter as python3 -> python -> py (Windows has no real `python3`, only a Store stub that must be rejected); no-op if none is
 # on PATH. Never blocks.
-PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || command -v py 2>/dev/null)
+PY=
+for _cand in python3 python py; do
+    _path=$(command -v "$_cand" 2>/dev/null) || continue
+    # Being on PATH is not the same as working. Windows ships a 0-byte Microsoft Store
+    # stub named python3.exe in %LOCALAPPDATA%\Microsoft\WindowsApps: `command -v` finds
+    # it, exec'ing it prints "Python was not found" and exits non-zero. Taking the first
+    # name that resolves made every hook fail on a machine that had a perfectly good
+    # python.exe one PATH entry away. Run the candidate before trusting it.
+    "$_path" -c '' >/dev/null 2>&1 || continue
+    PY=$_path
+    break
+done
 [ -n "$PY" ] || exit 0
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 exec "$PY" "$DIR/silent_execute_guard.py"

--- a/hooks/tdd-enforcement.sh
+++ b/hooks/tdd-enforcement.sh
@@ -2,9 +2,20 @@
 # PostToolUse TDD guard for Write|Edit (iris-interop-skills) — reminds to write the
 # test first when an interop component class is written without a sibling *Test*.cls.
 # Thin wrapper: exec the .py so the hook JSON on stdin reaches Python. Resolves the
-# interpreter as python3 -> python -> py (Windows has no `python3`); no-op if none is
+# interpreter as python3 -> python -> py (Windows has no real `python3`, only a Store stub that must be rejected); no-op if none is
 # on PATH. Never blocks.
-PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || command -v py 2>/dev/null)
+PY=
+for _cand in python3 python py; do
+    _path=$(command -v "$_cand" 2>/dev/null) || continue
+    # Being on PATH is not the same as working. Windows ships a 0-byte Microsoft Store
+    # stub named python3.exe in %LOCALAPPDATA%\Microsoft\WindowsApps: `command -v` finds
+    # it, exec'ing it prints "Python was not found" and exits non-zero. Taking the first
+    # name that resolves made every hook fail on a machine that had a perfectly good
+    # python.exe one PATH entry away. Run the candidate before trusting it.
+    "$_path" -c '' >/dev/null 2>&1 || continue
+    PY=$_path
+    break
+done
 [ -n "$PY" ] || exit 0
 DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 exec "$PY" "$DIR/tdd_enforcement.py"


### PR DESCRIPTION
All six hooks took the first interpreter name `command -v` resolved:

```sh
PY=$(command -v python3 2>/dev/null || command -v python 2>/dev/null || command -v py 2>/dev/null)
```

**Being on PATH is not the same as working.** Windows ships a 0-byte Microsoft Store stub named `python3.exe` in `%LOCALAPPDATA%\Microsoft\WindowsApps`. It satisfies `command -v`; exec'ing it prints *"Python was not found"* and exits non-zero.

So every hook failed on a machine with a perfectly good `python.exe` one PATH entry away. Found on the workshop VM image: the **PreToolUse conformance gate never ran at all**, and every `iris_doc`/`iris_compile`/`iris_execute` reported a hook failure.

The comments already said *"Windows has no `python3`"* — the trap wasn't that it's missing, but that a **fake one exists and wins**.

## Fix

Execute each candidate with `-c ''` before trusting it; fall through on failure. Behaviour when nothing works is unchanged — `exit 0`, never block real work on a missing interpreter.

## Verified

With a stub that exits 9009 like the real one:

| | old logic | new logic |
|---|---|---|
| picks | the stub → `Python was not found` | the real interpreter |

With the stub first on PATH, the gate still **allows** a conforming class and still **denies** a non-conforming one with the proper `permissionDecision: deny` payload. With *only* a broken interpreter available it stays silent and exits 0. `sh -n` clean on all six.

## Note for the workshop image

This does **not** replace the image-side fix — the VM image already has the plugin installed, so it also carries a real `C:\Python314\python3.exe` (AMI `ami-065ebe57117a6a27d`). This PR protects any other Windows user who installs the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)