### PR TITLE
feat(skills): say what class an object property inside a message should be (CR-11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ call (e.g. `check_config`) runs without a prompt.
 | `message-search-debug` | Message search, Visual Trace, the Event Log. |
 | `tdd` | TDD-first workflow (companion skill — load it alongside the others). |
 | `unit-tests` | `%UnitTest` framework reference. |
-| `conformance-review` | Post-build best-practice review (criteria CR-1…CR-10) — run it once a build is TDD-green. |
+| `conformance-review` | Post-build best-practice review (criteria CR-1…CR-11) — run it once a build is TDD-green. |
 | `report-issue` | Optionally propose a **deduped, user-confirmed** GitHub issue for a confirmed compliance violation or a reproducible MCP/skill defect (never auto-files; batches findings). |
 
 ### Agents (`agents/`)
@@ -212,7 +212,7 @@ Claude delegate based on the task description:
 | `interop-builder` | Build/modify any interop component end-to-end with TDD — loads the right skills, writes the test first, implements via the MCP, returns only when it compiles and the test is green. |
 | `deploy-smoke-test` | Start a production, feed a sample input, and verify the message actually flowed (Event Log + Message Header + downstream target). |
 | `introspect-dont-guess` | Resolve real class/table/column/config names from the live IRIS catalog instead of guessing (prevents nonexistent-table errors). |
-| `conformance-reviewer` | After a build is TDD-green, review it against the best-practice criteria (CR-1…CR-10) — re-verifies tests via the real `iris_test` (not a self-graded `[SqlProc]`), reports findings + a scoped remediation plan, applies only unambiguous fixes after you confirm. |
+| `conformance-reviewer` | After a build is TDD-green, review it against the best-practice criteria (CR-1…CR-11) — re-verifies tests via the real `iris_test` (not a self-graded `[SqlProc]`), reports findings + a scoped remediation plan, applies only unambiguous fixes after you confirm. |
 
 The agents are **MCP-server-agnostic** (no server name pinned in their tools), so they work with either
 the `iris-agentic-dev` or `iris-interop-dev` MCP.

--- a/agents/conformance-reviewer.md
+++ b/agents/conformance-reviewer.md
@@ -12,7 +12,7 @@ approves a remediation item.
 
 ## The criteria are not in your memory — load them
 
-`Skill(iris-interop-skills:conformance-review)` is the **single source of truth** (criteria CR-1…CR-10).
+`Skill(iris-interop-skills:conformance-review)` is the **single source of truth** (criteria CR-1…CR-11).
 Load it first, then load the component skills for whatever is in the build so you judge against their
 guidance, not recollection: `iris-interop-skills:interop` (naming/router) plus `:bpl`,
 `:business-services`, `:transformations`, `:alerting`, `:hl7-schemas`, `:messages`, `:tdd` as applicable.
@@ -26,7 +26,7 @@ guidance, not recollection: `iris-interop-skills:interop` (naming/router) plus `
    `%UnitTest.TestProduction` class and record the genuine result. A build that "passed" only through a
    self-authored `[SqlProc]` runner read with `iris_query` is **unverified** — flag CR-7 as P0. If
    `iris_test` errors, that is a finding, not a pass.
-3. **Check every criterion** CR-1…CR-10 against the actual code. For each, cite `file:line` and state the
+3. **Check every criterion** CR-1…CR-11 against the actual code. For each, cite `file:line` and state the
    best-practice it meets or breaks. Be specific; a pass-through BP, a `$Piece` file loop, a `<code>`-only
    DTL, a `MSH:9.x` rule, an unfed alert circuit, a hardcoded path — name the exact line.
 4. **Separate verdicts from judgment calls.** Some "violations" are defensible (the criteria table marks

--- a/hooks/conformance_prescan.py
+++ b/hooks/conformance_prescan.py
@@ -2,8 +2,8 @@
 """PostToolUse conformance pre-scan for Write|Edit of IRIS .cls (iris-interop-skills).
 
 Cheap, deterministic pre-screen: when an interop class is written, scan that ONE file's
-text for the mechanically-detectable anti-patterns (the ⚙ criteria CR-1/2/4/5/7/10 in the
-conformance-review skill). If any match, nudge the model to run the conformance-reviewer
+text for the mechanically-detectable anti-patterns (the ⚙ criteria CR-1/2/4/5/7/10/11 in
+the conformance-review skill). If any match, nudge the model to run the conformance-reviewer
 agent for the real (cross-file, semantic) review. Advisory only — never blocks, only emits
 additionalContext, and stays silent when nothing matches. The agent, not this hook, is the
 source of the verdict; this only decides whether a review is worth running.
@@ -49,6 +49,16 @@ CHECKS = [
     ("CR-10", "hardcoded absolute path in a class",
      [r'"[A-Za-z]:\\|"/tmp/|"/usr/'],
      []),
+    # CR-11 fires on the PAYLOAD class, not on the message that carries it. The message is
+    # undecidable from one file: `Property Address As MyApp.DAT.Address` is the same text
+    # whether Address is %SerialObject (correct) or %Persistent (leaks) — the type lives in
+    # another file, so checking there would flag the correct, common case on every write.
+    # The payload itself IS decidable, and being declared %Persistent is the moment the
+    # decision goes wrong. Cross-file confirmation (is it referenced by a message at all?
+    # does that message cascade?) is the reviewer agent's job, not this hook's.
+    ("CR-11", "persistent message payload with no delete cascade — purge will orphan its rows",
+     [r"Class\s+[\w.]*\.(?:DAT|MSG)\.[\w.]+\s+Extends\s*[\s(][^{]*%Persistent"],
+     [r"Ens\.(?:Request|Response|Business|DataTransform)", r"\bTrigger\s+\w+", r"%OnDelete"]),
 ]
 
 

--- a/skills/conformance-review/SKILL.md
+++ b/skills/conformance-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conformance-review
-description: Review an already-built IRIS Interoperability production against the iris-interop best-practice criteria AFTER implementation + TDD, and report what does not conform with the canonical fix. Use after building/modifying components, before declaring done, or whenever the user asks "is this implemented correctly / per best practices / conforme". This skill is the single source of truth for the conformance criteria (CR-1…CR-10); the `conformance-reviewer` agent and the `conformance-prescan` hook both check against it. Triggers EN: review, conformance, best practices, is this correct, code review, ready to ship. Triggers ES: revisar, conformidad, buenas prácticas, está bien implementado, cumple, revisión.
+description: Review an already-built IRIS Interoperability production against the iris-interop best-practice criteria AFTER implementation + TDD, and report what does not conform with the canonical fix. Use after building/modifying components, before declaring done, or whenever the user asks "is this implemented correctly / per best practices / conforme". This skill is the single source of truth for the conformance criteria (CR-1…CR-11); the `conformance-reviewer` agent and the `conformance-prescan` hook both check against it. Triggers EN: review, conformance, best practices, is this correct, code review, ready to ship. Triggers ES: revisar, conformidad, buenas prácticas, está bien implementado, cumple, revisión.
 ---
 
 # IRIS Interoperability — Conformance Review
@@ -23,7 +23,7 @@ re-plan from scratch and it never rewrites silently.
 2. **Load the relevant skills** so you judge against their guidance, not memory: `iris-interop-skills:interop`
    (router/naming), plus the component skills in play (`:bpl`, `:business-services`, `:transformations`,
    `:alerting`, `:hl7-schemas`, `:messages`, `:tdd`).
-3. **Check every criterion below** (CR-1…CR-10) against the actual code. Cite `file:line` and the exact
+3. **Check every criterion below** (CR-1…CR-11) against the actual code. Cite `file:line` and the exact
    best-practice it meets or breaks.
 4. **Re-verify tests for real** (CR-7): run `iris_test` on the test class; record the genuine result.
 5. **Emit the report** (severity-tagged) → **a scoped remediation plan** → offer to **apply the safe
@@ -37,7 +37,7 @@ re-plan from scratch and it never rewrites silently.
 - **P2** — idiomatic gap that works but loses tooling/robustness (declarative vs procedural; missing alerts).
 - **P3** — cosmetic / naming / hardcoded paths.
 
-## Criteria (CR-1 … CR-10)
+## Criteria (CR-1 … CR-11)
 
 Items marked **⚙ pre-scannable** are also detected mechanically by the `conformance-prescan` hook from a
 single file's text; the rest need the agent's cross-file/semantic judgment.
@@ -54,6 +54,7 @@ single file's text; the rest need the agent's cross-file/semantic judgment.
 | **CR-8** | P2 | HL7/REST message fields typed as non-`%String` (forced by `EnsLib.HL7`/REST string semantics), except genuinely typed synthetic fields. | Type HL7/REST-sourced message properties `As %String`. | `messages` |
 | **CR-9** | P3 | Naming: classes not `<Pkg>.<Tipo>.<Nombre>` (`.BS`/`.BP`/`.BO`/`.DT`/`.RUL`/`.MSG`), or production **Item Name** not `<Tipo>.<Nombre>`; Category ≠ package root. | Apply the interop naming convention; Category = package root; fixed `Ens.Alerts`. | `interop` |
 | **CR-10** ⚙ | P3 | A `.cls` with a **hardcoded absolute path** (`C:\…`, `/tmp/…`) instead of resolving relative to the install/source dir. | Parametrize via a Setting, or resolve with `##class(%Library.File).TempFilename`/`InstallDirectory`. | `production-lifecycle` |
+| **CR-11** ⚙ | P2 | An **object property of a message resolved to a `%Persistent` class with no delete cascade** — no `Trigger [ Event = DELETE ]` and no `%OnDelete` on the referencing message, no `OnDelete = Cascade` on the link. `Ens.Util.Tasks.Purge` then deletes the message and orphans the child rows, silently, forever. | Make it `%SerialObject` in `<Pkg>.DAT.<Name>` if it's a value object owned by the message (the default); if it must be `%Persistent` (shared / queried on its own / recursive / large), add the delete cascade to the **referencing** message class. | `messages` |
 
 ## Output template
 

--- a/skills/interop/SKILL.md
+++ b/skills/interop/SKILL.md
@@ -124,7 +124,7 @@ System Default Settings are the **only** layer that does NOT migrate via a produ
 | **Securing endpoints** — SAML 2.0 / 1.1, OAuth 2.0 server + LDAP, SSL/TLS chain, internal account hygiene | `iris-interop-skills:security` |
 | **Alert circuit** — `Ens.Alert` router, dedup function set, ProductionMonitorService, per-BO alert settings | `iris-interop-skills:alerting` |
 | **About to build *anything* (DTL, rule, BO method, BPL) — TDD workflow** | **`iris-interop-skills:tdd`** (entry point; non-negotiable) |
-| **Built it and TDD-green — is it idiomatic / per best practices?** (run before declaring done) | **`iris-interop-skills:conformance-review`** (criteria CR-1…CR-10; the `conformance-reviewer` agent runs it) |
+| **Built it and TDD-green — is it idiomatic / per best practices?** (run before declaring done) | **`iris-interop-skills:conformance-review`** (criteria CR-1…CR-11; the `conformance-reviewer` agent runs it) |
 | %UnitTest framework toolbox (storage, runner flags, ^UnitTest.Result) | `iris-interop-skills:unit-tests` (lower-level reference; the TDD skill calls into it) |
 | Anything DICOM (C-STORE, C-FIND, C-MOVE, MWL, STOW-RS, modalities, PACS) | `iris-interop-skills:dicom` (architecture + wiring patterns; defers byte-level work to docs + vendored sample at `${CLAUDE_PLUGIN_ROOT}/BestPractices/external/workshop-iris-dicom-interop/`) |
 
@@ -187,7 +187,7 @@ For a typical end-to-end interface, work in this order — it minimises rework b
 9. **Production wiring + settings** (`production-lifecycle`) — add `TestingEnabled="true"` for dev productions; choose deployment tool early
 10. **Security** (`security`) — only after components exist; SAML/OAuth/SSL added where the endpoints actually call out
 11. **Test, search, debug** (`message-search-debug`) — Visual Trace + Event Log for verifying end-to-end runs; purge task added
-12. **Conformance review** (`conformance-review`) — once built and TDD-green, review against the best-practice criteria (CR-1…CR-10) before declaring done; spawn the `conformance-reviewer` agent. It re-verifies tests via the real `iris_test` tool (never a self-graded `[SqlProc]`), reports findings with the canonical fix, and proposes a scoped remediation plan.
+12. **Conformance review** (`conformance-review`) — once built and TDD-green, review against the best-practice criteria (CR-1…CR-11) before declaring done; spawn the `conformance-reviewer` agent. It re-verifies tests via the real `iris_test` tool (never a self-graded `[SqlProc]`), reports findings with the canonical fix, and proposes a scoped remediation plan.
 
 For FHIR-specific work, replace steps 4–7 with the `fhir` decision tree (Façade vs Repository, OAuth2 PKCE setup, FHIR R4 Bundle shape).
 

--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -24,6 +24,9 @@ Is the data HL7 v2.x?
     │   │         wrapped in an Ens.Request/Response carrier.
     │   └── NO
     │       └── Custom payload → persistent message (see below)
+    │           └── Any property an object rather than a scalar?
+    │               → see "Complex properties" below — the sub-object's
+    │                 class type is a decision, not a detail.
 ```
 
 ## Canonical pattern — custom persistent message
@@ -43,6 +46,72 @@ Storage Default { /* lives in MyApp.Msg.PatientCensusRequestD, not Ens.MessageBo
 
 Pair Request with a Response class extending `(Ens.Response, %Persistent)`. If the operation is fire-and-forget, return `Ens.Response` directly — no custom Response class needed.
 
+## Complex properties — what class for an object inside a message
+
+The canonical example above is all scalars. As soon as a property is an **object** — an `Address`
+inside a `Person`, a `Coverage` inside a `Claim` — you are choosing a storage model, and the wrong
+choice fails silently months later.
+
+**Default to `%SerialObject`.** `Address` has no life of its own: it isn't queried on its own, isn't
+shared between messages, and dies with its `Person`. A `%SerialObject` serialises **inline into the
+message's own row**, so purging the message takes the address with it. Nothing else to wire.
+
+Name it per the existing convention (`interop`, naming table): internal `%SerialObject` data classes
+go in the **`.DAT`** sub-package.
+
+```objectscript
+Class MyApp.DAT.Address Extends (%SerialObject, %XML.Adaptor)
+{
+Property Calle    As %String(MAXLEN = 200);
+Property Ciudad   As %String(MAXLEN = 100);
+Property CodPostal As %String(MAXLEN = 10);
+}
+
+Class MyApp.MSG.PersonReq Extends (Ens.Request, %Persistent)
+{
+Property Nombre  As %String(MAXLEN = 100);
+Property Address As MyApp.DAT.Address;   // embedded — purged with the message
+}
+```
+
+**Switch to `%Persistent` only for a reason.** There are four, and "it felt more real" is not one:
+
+| Situation | Type | What else is required |
+|---|---|---|
+| Value object, owned by one message (`Address`, `Contact`, `Amount`) | `%SerialObject` | Nothing — purge is automatic |
+| **Shared** by several messages, or referenced after the message is purged | `%Persistent` | Delete cascade on the carrier (below) |
+| Must be **queried on its own** (SQL, `message-search-debug`, reporting) | `%Persistent` | Delete cascade + indexes |
+| **Recursive** (`Component` containing `Component` — CDA sections) | `%Persistent` | Delete cascade — a recursive `%SerialObject` won't even compile (cyclic reference) |
+| **Large** (>100 KB serialised) and retained in volume | `%Persistent` | Delete cascade — keeps `Ens.MessageBodyD` from bloating |
+
+### If it is `%Persistent`, the delete cascade is not optional
+
+A `%Persistent` sub-object gets **its own row**. `Ens.Util.Tasks.Purge` deletes `Ens.MessageHeader`
+and the message row — it does **not** know about the child. The child rows accumulate forever, with
+no error and nothing in the Event Log; you find out when the table is the biggest thing in the
+namespace.
+
+The cascade goes on the class that **references** the object — the message — not on the child:
+
+```objectscript
+Class MyApp.MSG.PersonReq Extends (Ens.Request, %Persistent)
+{
+Property Address As MyApp.DAT.Address;   // %Persistent in this variant
+
+Trigger DeleteCascade [ Event = DELETE, Foreach = row/object ]
+{
+    Do ##class(MyApp.DAT.Address).%DeleteId({Address})
+}
+}
+```
+
+Equivalent alternatives: override `%OnDelete` on the message and clean the references explicitly, or
+— for parent-child hierarchies generated from an XSD — declare `OnDelete = Cascade` on the link (see
+the CDA-from-XSD section below).
+
+This is the same rule the SOAP wizard case runs into; `soap-bo` covers the wizard-specific angle
+(it generates `%SerialObject` payloads and never generates the trigger for you).
+
 ## Canonical pattern — HL7 message
 
 Don't create a class. Use `EnsLib.HL7.Message` everywhere a message body is referenced:
@@ -55,7 +124,7 @@ The DocType (e.g. `2.5:ADT_A01`) controls structure; it's set on the BS adapter 
 
 ## Canonical pattern — SOAP-wizard messages
 
-SOAP wizard output: payload classes typically `%SerialObject` (embedded, no separate storage). For very complex SOAP messages — e.g. a CDA wrapped in SOAP, with deeply recursive structures — switch the payload to `%Persistent` so each instance gets its own storage and the recursion doesn't blow up `Ens.MessageBodyD`. Add a delete trigger so child rows are cleaned up on parent purge.
+SOAP wizard output: payload classes typically `%SerialObject` (embedded, no separate storage) — the same default as any hand-written sub-object. For very complex SOAP messages — e.g. a CDA wrapped in SOAP, with deeply recursive structures — switch the payload to `%Persistent` so each instance gets its own storage and the recursion doesn't blow up `Ens.MessageBodyD`, and add the delete cascade per **Complex properties** above. The wizard does not generate the trigger for you.
 
 ## CDA-from-XSD persistence pattern
 
@@ -118,7 +187,8 @@ Worked example: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch05_bpl_dtl/xml-p
 - **Putting business properties on the carrier instead of the payload** in SOAP scenarios → wizard regeneration overwrites them.
 - **Missing pair**: Request without matching Response when the operation is synchronous and the BP expects a typed response.
 - **Forgetting indexes** on properties used by `message-search-debug` — message search is fast only on indexed properties.
-- **Recursive properties on a `%SerialObject`** (e.g. CDA's nested sections) → switch to `%Persistent` and add a delete trigger.
+- **An object property typed `%Persistent` "to be safe", with no delete cascade** → the child rows survive every purge. No error, nothing in the Event Log, the table just grows forever. Either make it `%SerialObject` (the default for a value object) or add the trigger — see **Complex properties**.
+- **Recursive properties on a `%SerialObject`** — a class that contains itself (CDA's nested sections are the classic case) → cyclic-reference compile error; switch to `%Persistent` and add the delete cascade.
 - **Adding `SourceFilename` / `SourceLine` to a message that comes from a Record Mapper Record** for CSV-line forensics → Record Mapper doesn't fill those properties at runtime, even if you declare them. If you need this correlation, propagate from the BS adapter (e.g. `Ens.MessageHeader` carries `%Source` / `%FileName` from the file adapter) instead of adding properties that stay empty.
 
 ## Testing / how to verify
@@ -181,6 +251,11 @@ SELECT COUNT(*) FROM <Pkg>_Msg.<Parent>_AlergiasList WHERE <Parent> = :id
 
 Don't substitute a pipe-string property for a typed collection if downstream consumers want collection semantics — the conversion belongs in the DTL one time, not in every consumer.
 
+For `list Of <ObjectClass>`, the `<ObjectClass>` follows the same rule as any object property — see
+**Complex properties**: `%SerialObject` unless one of the four reasons applies, and a delete cascade
+if it ends up `%Persistent`. A collection multiplies the leak: N orphaned child rows per message
+instead of one.
+
 ## When NOT to use this skill — fall back to docs
 
 - Designing FHIR resources (use `HS.FHIR.*` patterns — different from generic Interop messages).
@@ -194,3 +269,5 @@ Don't substitute a pipe-string property for a typed collection if downstream con
 - `hl7-schemas` — when the HL7 message needs a custom Z-segment schema
 - `soap-bo` — SOAP wizard customisations, including `xsi:type` suppression and other generated-proxy patches
 - `fhir` — FHIR resources are not generic Interop messages; different rules apply
+- `message-search-debug` — where the purge that exposes a missing delete cascade actually runs
+- `production-lifecycle` — `Ens.Util.Tasks.Purge` belongs in the production from day one

--- a/skills/report-issue/SKILL.md
+++ b/skills/report-issue/SKILL.md
@@ -17,7 +17,7 @@ This skill turns a confirmed problem into a **draft** issue and proposes it to t
 
 ## What's reportable
 
-- **Compliance / best-practice** (from `conformance-review`): a *confirmed* P0/P1 finding (CR-1…CR-10).
+- **Compliance / best-practice** (from `conformance-review`): a *confirmed* P0/P1 finding (CR-1…CR-11).
   Not P2/P3 nits, not unconfirmed/defensible calls.
 - **MCP / skill defect**: a *reproducible* tool malfunction in the deployed version — a tool that returns a
   wrong/empty result, an error_code that doesn't match reality, a crash, a skill that misroutes. Must have a

--- a/skills/soap-bo/SKILL.md
+++ b/skills/soap-bo/SKILL.md
@@ -30,6 +30,10 @@ When the WSDL declares a string type **without a length facet**, the wizard-gene
 
 ## Storage decision: %SerialObject vs %Persistent for payloads
 
+> The general rule for **any** object property inside a message — not just wizard output — lives in
+> `messages` (**Complex properties**): `%SerialObject` by default, `%Persistent` only for a reason,
+> and a delete cascade whenever it is `%Persistent`. This section is the SOAP-specific slice.
+
 The wizard generates payload classes (the WSDL types). By default these are `%SerialObject` — embedded inside the carrying request/response, no separate storage. **Change to `%Persistent` when:**
 
 | Symptom / situation | Use %Persistent + delete trigger |
@@ -54,7 +58,7 @@ Trigger DeleteCascade [ Event = DELETE, Foreach = row/object ]
 }
 ```
 
-Or, equivalently, override `%OnDelete` on the carrier to clean up the payload references explicitly. The wizard does NOT generate this for you — you have to add it after switching to `%Persistent`.
+Or, equivalently, override `%OnDelete` on the carrier to clean up the payload references explicitly. **The wizard does NOT generate this for you** — you have to add it after switching to `%Persistent`. That is the SOAP-specific trap: the rest of the reasoning, and the reference-property form of the trigger, are in `messages`.
 
 ## Properties on the carrier vs the payload
 


### PR DESCRIPTION
## The gap

`messages` never answered the most ordinary design question there is: a `Person` message with an `Address` inside it — **what class is `Address`?**

The guidance existed, but only as the SOAP wizard's problem:

| Where | Framing |
|---|---|
| `soap-bo` §31-57 | the full `%SerialObject`-vs-`%Persistent` decision + the delete trigger — under "payloads the wizard generates" |
| `messages:58` | one line, under "Canonical pattern — **SOAP-wizard** messages" |
| `messages:121` | a pitfall, scoped to "recursive properties (e.g. **CDA's** nested sections)" |

The decision tree stopped at `Custom payload → persistent message`, and the canonical example is all scalars. Someone hand-writing a message with a sub-object never reaches any of it. `messages:176` even offers `list Of <ObjectClass>` without saying what `<ObjectClass>` should be.

Both failure modes are silent and expensive:

- **`%Persistent` sub-object, no cascade** → it survives every `Ens.Util.Tasks.Purge`. No error, nothing in the Event Log; the child table just grows until it's the biggest thing in the namespace.
- **Recursive `%SerialObject`** → cyclic-reference compile error.

## What changed

- **`messages`** — new **Complex properties** section: `%SerialObject` by default (named `<Pkg>.DAT.<Name>`, the convention `interop` already defines), the four reasons to go `%Persistent` (shared / queried on its own / recursive / large), and the delete cascade that is then mandatory. The trigger goes on the **referencing** message, keyed on the reference property. Decision tree, Common pitfalls, `list Of <ObjectClass>` and See also updated to match.
- **`soap-bo`** — keeps the wizard-specific slice (it generates `%SerialObject` payloads and *never* generates the trigger) and delegates the general rule to `messages`, exactly as it already delegates the `MAXLEN=50` trap.
- **`conformance-review`** — **CR-11**, P2: it compiles, tests pass, and the cost lands in production months later.
- **`conformance_prescan`** — CR-11 fires on the **payload** class, not on the message.

## Why the hook checks the payload and not the message

The message is undecidable from one file:

```objectscript
Class MyApp.MSG.PersonReq Extends (Ens.Request, %Persistent)
{
Property Address As MyApp.DAT.Address;   // identical text whether Address is
}                                        // %SerialObject (correct) or %Persistent (leaks)
```

The type lives in another file, so a check there would flag the correct — and far more common — case on every single write. The payload **is** decidable, and declaring it `%Persistent` is the moment the decision goes wrong. Cross-file confirmation (is it referenced by a message at all? does that message cascade?) stays with the reviewer agent, which is what the hook's docstring already says its job is.

## Verification

Against the real hooks via stdin, not by reading the regexes:

| Case | CR-11 |
|---|---|
| `Address` as `%Persistent`, no cascade | **fires** |
| `Address` as `%SerialObject` | silent |
| `Address` as `%Persistent` with `%OnDelete` | silent |
| `PersonReq` carrying `Address` | silent |
| message with only scalars / `list Of %String` | silent |
| message carrying `EnsLib.HL7.Message` | silent |
| message with `Trigger DeleteCascade` already | silent |
| plain Business Service | silent |

No regressions: CR-1 / CR-2 / CR-10 still fire on their own fixtures. And `interop_conformance_gate.py` allows `.DAT` and `.MSG` while still denying `.Message.` — so the recommended package name isn't blocked by the gate.

Not verified: a live `iris_doc` round-trip (no IRIS connected on this machine). The hook logic is text-only, so the stdin harness exercises the same code path the hook runs in production.

## Not in scope

Plugin version untouched (1.5.9 — bumps go in their own `chore:` release commit, as with #3), and `interop_conformance_gate.py` untouched: this is a design recommendation, not an unambiguous violation, and the gate only denies what is indisputable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)