### PR TITLE
feat(message-search-debug): trigger on verification, not just failure; document headless resend

### DIFF
--- a/skills/interop/SKILL.md
+++ b/skills/interop/SKILL.md
@@ -119,7 +119,7 @@ System Default Settings are the **only** layer that does NOT migrate via a produ
 | Production class structure, start/stop, settings, deployment, migration | `iris-interop-skills:production-lifecycle` |
 | Custom HL7 schemas, Z-segments, schema editor | `iris-interop-skills:hl7-schemas` |
 | Lookup tables (creating, loading, using in DTL) | `iris-interop-skills:lookup-tables` |
-| Searching messages, Visual Trace, Event Log, debugging, testing live components, SOAP tracing, purge | `iris-interop-skills:message-search-debug` |
+| **Looking at a RUNNING production for any reason** — did it arrive, how many rows landed, what did session N do, resend a message, queue depth, Visual Trace, Event Log, testing live components, SOAP tracing, purge. **Verifying a run that worked counts — not just debugging one that didn't.** | **`iris-interop-skills:message-search-debug`** — load it *before* writing any query against `Ens.MessageHeader` / `Ens_Util.Log` |
 | **FHIR work** — Façade vs Repository, OAuth2 PKCE, FHIR R4 Bundles, FHIR SQL Builder | `iris-interop-skills:fhir` |
 | **Securing endpoints** — SAML 2.0 / 1.1, OAuth 2.0 server + LDAP, SSL/TLS chain, internal account hygiene | `iris-interop-skills:security` |
 | **Alert circuit** — `Ens.Alert` router, dedup function set, ProductionMonitorService, per-BO alert settings | `iris-interop-skills:alerting` |
@@ -150,7 +150,8 @@ involved, issue several `Skill(...)` calls in the same turn.
 - Non-SOAP Business Operation → `Skill(iris-interop-skills:business-operations)`; SOAP BO → `Skill(iris-interop-skills:soap-bo)`.
 - Production class / start-stop / settings / deploy → `Skill(iris-interop-skills:production-lifecycle)`.
 - Custom HL7 schema → `Skill(iris-interop-skills:hl7-schemas)`; lookup tables → `Skill(iris-interop-skills:lookup-tables)`.
-- Searching/debugging live messages → `Skill(iris-interop-skills:message-search-debug)`.
+- **Any look at a running production** — verifying a run landed, searching messages, tracing a session,
+  resending → `Skill(iris-interop-skills:message-search-debug)`. Checking your own work counts.
 - FHIR → `Skill(iris-interop-skills:fhir)`; endpoint security → `Skill(iris-interop-skills:security)`;
   alert circuit → `Skill(iris-interop-skills:alerting)`; DICOM → `Skill(iris-interop-skills:dicom)`.
 

--- a/skills/message-search-debug/SKILL.md
+++ b/skills/message-search-debug/SKILL.md
@@ -71,6 +71,75 @@ Everything else — listing a session's messages, tailing the Event Log, followi
 end, queue depths — has a typed call, and the typed call is one round trip against a table name you
 would otherwise guess. Use the table above; drop to SQL only for the three cases here.
 
+## Searching by message content — the two joins
+
+`Ens.MessageHeader` holds no business data: it carries `MessageBodyClassName` (which class) and
+`MessageBodyId` (which row). To search on what the message *says*, join to the body.
+
+### Join 1 — header to a custom message class
+
+The join key is always `h.MessageBodyId = <BodyClass>.ID`. The SQL name of the body class is its
+package with dots turned into underscores **except the last** — `Ejercicio3.MSG.MenuReq` becomes
+`Ejercicio3_MSG.MenuReq`:
+
+```sql
+SELECT TOP 5 h.ID, h.SessionId, h.SourceConfigName, h.Status, r.PacienteId, r.FechaNacimiento
+FROM   Ens.MessageHeader h
+JOIN   Ejercicio3_MSG.MenuReq r ON h.MessageBodyId = r.ID
+WHERE  h.SourceConfigName = 'Router.Censo'
+ORDER  BY h.ID DESC
+```
+
+Filter on a body property to find every message about one entity —
+`WHERE h.TargetConfigName='BO.Menus' AND r.PacienteId='4003'`. **Read `MessageBodyClassName` first**:
+one production carries several body classes, and each needs its own join. Alerts are
+`Ens.AlertRequest` (`a.AlertText`) — `LEFT JOIN` it, since non-alert rows have no match. There is no
+`EnsLib_Messaging.AlertRequest`; guessing it costs a round trip.
+
+Only worth doing when the body class is `%Persistent` with the property indexed — see `messages`.
+A body sitting in `Ens.MessageBodyD` without a typed class is a full-table scan.
+
+### Join 2 — header to a Search Table (HL7 and other virtual documents)
+
+An HL7 body has no columns to join to, so **Search Tables** are the indexed path. A developer writes
+**one subclass per use case** (`Hospital.Search.HL7 Extends EnsLib.HL7.SearchTable`, with an
+`XData SearchSpec` naming the fields), but — this is the part that surprises people — **the subclass
+gets no table of its own**. Every HL7 search table in the namespace stores its rows in the shared
+base extent `EnsLib_HL7.SearchTable`:
+
+| Table | Columns |
+|---|---|
+| `EnsLib_HL7.SearchTable` | `ID`, `DocId`, `PropId`, `PropValue` — `DocId` **is** `Ens.MessageHeader.MessageBodyId` |
+| `Ens_Config.SearchTableProp` | `ID`, `Name`, `PropId`, `ClassExtent`, `ClassDerivation`, `PropType`, `IndexType`, … |
+
+So you select a search table's fields by **`PropId`**, never by table name:
+
+```sql
+SELECT TOP 10 h.ID, h.SessionId, h.SourceConfigName, p.Name, st.PropValue
+FROM   Ens.MessageHeader h
+JOIN   EnsLib_HL7.SearchTable st ON st.DocId = h.MessageBodyId
+JOIN   Ens_Config.SearchTableProp p
+       ON p.PropId = st.PropId AND p.ClassExtent = 'EnsLib.HL7.SearchTable'
+WHERE  p.Name = 'PatientID' AND st.PropValue = '16284718'
+```
+
+- **Join the catalogue on `PropId`, not on `ID`.** `Ens_Config.SearchTableProp.ID` is composite —
+  `EnsLib.HL7.SearchTable||Medication` — so `ON p.ID = st.PropId` compiles, returns zero rows, and
+  looks like "no data".
+- **`PropId` is unique only within a `ClassExtent`.** Without the `ClassExtent` predicate you match
+  X12/EDIFACT/ASTM/XML props that share the number.
+- **`ClassDerivation` tells you which subclass declared a prop** — `Hospital.Search.HL7~EnsLib.HL7.SearchTable`.
+  Filter `p.ClassDerivation LIKE 'Hospital.Search.HL7~%'` to scope to one use case.
+- Built-in HL7 props occupy the low ids (`MSHControlID`=1, `MSHTypeName`=2, `PatientAcct`=3,
+  `PatientID`=4, `PatientName`=5); custom ones are appended (`Medication`=12).
+- A field only becomes searchable **after** `SearchTableClass` is set on the BS/BO item, target
+  `Host` — and only for messages received from that point on. Existing messages are not back-indexed.
+
+Non-HL7 virtual documents follow the same shape with their own base extent
+(`EnsLib_EDI_X12.SearchTable`, `EnsLib_EDI_XML.SearchTable`, …). Custom non-VDoc search tables
+extend `Ens.CustomSearchTable`, whose own extent is `Ens.CustomSearchTable` with the same
+`DocId` key.
+
 ## Searching by message body content
 
 Searchable when:

--- a/skills/message-search-debug/SKILL.md
+++ b/skills/message-search-debug/SKILL.md
@@ -1,15 +1,23 @@
 ---
 name: message-search-debug
-description: Visual Trace, Event Log, message search, debug. Routed from interop. Triggers: Message Viewer, Visual Trace, Event Log, message search, buscar mensaje, depurar, debug, resend, reenviar, troubleshoot, traza.
+description: Verify a run end-to-end, search messages, Visual Trace, Event Log, resend. Routed from interop. Load it whenever you are about to LOOK AT a running production — confirming a run worked counts, not only diagnosing a failure. Triggers EN: did it arrive, how many rows landed, verify end-to-end, check the run, Message Viewer, Visual Trace, Event Log, message search, resend, troubleshoot, queue depth. Triggers ES: verificar, comprobar, ha llegado, cuántos mensajes, ha funcionado, buscar mensaje, reenviar, depurar, traza, cola.
 ---
 
 # Message Search & Debug
 
-Operational troubleshooting on an IRIS Interop production. Four tools cover 95% of the work (Message Viewer, Visual Trace, Event Log, Production Status); the remaining 5% is per-BO SOAP tracing, retention/purge tuning, and bulk-resend recipes.
+Everything you do **after** a message enters a running production: confirming it arrived, following where it went, and resending it. Four tools cover 95% of the work (Message Viewer, Visual Trace, Event Log, Production Status); the remaining 5% is per-BO SOAP tracing, retention/purge tuning, and bulk-resend recipes.
 
 ## When to use this skill
 
-The user is troubleshooting: a message didn't arrive, a transformation produced wrong output, a BO is red, the Event Log is full of warnings, etc. **Or** the user wants to manually test a single component live (Management Portal "Test" link on a BS/BO/BP) without writing automated tests. For automated unit tests, see `unit-tests` instead.
+**Not only when something is broken.** The most common use is verifying a run that went *fine*: "did the 13 rows land", "how many messages did the BS send", "show me what session 103 did". If you are about to query a production's runtime state for any reason, this is the skill.
+
+Also: the user is troubleshooting (a message didn't arrive, a transform produced wrong output, a BO is red), or wants to manually test a single component live (Management Portal "Test" link on a BS/BO/BP) without writing automated tests. For automated unit tests, see `unit-tests` instead.
+
+> **Why the framing matters.** Measured over one workshop cohort day: 18 students ran **295
+> hand-written SQL queries** against `Ens.MessageHeader` / `Ens_Util.Log` versus 113 typed
+> `iris_interop_query` calls, producing 57 `%qaqqt` errors on the way. **56% of that SQL was
+> counting/verifying** and 41% plain listing. They were not debugging — they were checking their
+> own work, so nobody thought to load a skill called "debug". Zero loads across the cohort.
 
 ## The four tools (and when to use which)
 
@@ -48,6 +56,21 @@ When inspecting a running production through the IRIS MCP, reach for `iris_inter
 
 If you do fall back to raw `iris_query` and hit "table not found", **read the `hint`** it returns — it names the typed tool for that exact case.
 
+### Where raw SQL IS the right answer
+
+`iris_interop_query` returns **rows of headers and log entries**. It does not aggregate and it does
+not join to the message body. For these, a plain `iris_query` is correct — not a fallback:
+
+| Need | Why the typed tool can't |
+|---|---|
+| `SELECT COUNT(*) … GROUP BY TargetConfigName, Status` — how many landed where | no aggregation |
+| Join `Ens.MessageHeader` to the message-body class to see business fields (`PacienteId`, …) | returns headers only |
+| `COUNT(*) FROM Ens_Util.Log WHERE Type = 2` — how many errors, by component | no aggregation |
+
+Everything else — listing a session's messages, tailing the Event Log, following one message end to
+end, queue depths — has a typed call, and the typed call is one round trip against a table name you
+would otherwise guess. Use the table above; drop to SQL only for the three cases here.
+
 ## Searching by message body content
 
 Searchable when:
@@ -61,6 +84,27 @@ Not efficiently searchable when:
 ## Resending
 
 From the Message Viewer, a message can be **resent** to its original target or to a new target. Useful after a fix on a downstream system. Resend creates a new session — the old session stays as an audit trail.
+
+### Headless resend — there is no MCP tool for this
+
+`iris_interop_query` has no resend mode (`what` accepts only `logs`, `queues`, `messages`, `trace`,
+`partners`). Without the Portal, resend one message by header ID with:
+
+```objectscript
+Set newId = "", sc = ##class(Ens.MessageHeader).ResendDuplicatedMessage(<headerId>, .newId)
+// sc = %Status; newId = the header ID of the new message
+```
+
+Run it through `iris_execute`; it persists (this is a runtime side effect, not class generation, so
+it does not hit the objectgenerator no-op trap). Verified on IRIS 2026.1: resending header `102`
+returned `$$$OK` and `newId = 171`, and the new session appeared in `Ens.MessageHeader` immediately.
+
+**`docs_introspect` will not help you find this method** — asking for
+`Ens.MessageHeader::ResendDuplicatedMessage` returns `{"methods":[],"properties":[],"success":true}`,
+an empty result that reads as "no such method". It exists; the introspection just doesn't surface it.
+
+Confirm the resend landed by header ID, not by re-listing everything:
+`iris_query("SELECT ID, SessionId, TargetConfigName, Status FROM Ens.MessageHeader WHERE ID >= <newId>")`.
 
 For bulk resends (a batch failed during an outage), filter Message Viewer to the affected window + status `Error`, select all, resend. Before bulk-resending: verify **idempotency** on the downstream BO. A non-idempotent BO will create duplicates — fix that first or use a manual loop with deduplication logic in the BP.
 


### PR DESCRIPTION
## The observation

**Zero loads across an 18-student cohort** — on the day they spent searching messages, tracing sessions and resending them.

The routing entry was not missing. The `interop` router lists this skill in three places and was itself loaded 747 times by 12 students. It simply never fired.

## What they did instead

| | count |
|---|---|
| hand-written SQL against `Ens.MessageHeader` / `Ens_Util.Log` | **295** |
| typed `iris_interop_query` calls | 113 |
| `%qaqqt` errors — the exact signature this skill warns about | 57 |

Four students never used the typed tool once. Of the 113 typed calls, 75 were `what=logs`; `trace`, the most powerful mode, was used 9 times in the whole cohort.

Classifying that SQL is what explains the miss:

```
56%  counting / verifying   (COUNT(*), SELECT TOP, MAX(ID))
41%  plain listing
10%  aggregation, joins to the message body
```

They were **not troubleshooting**. They were checking their own work — and a skill whose description opens with *"Visual Trace, Event Log, message search, debug"*, over a body that opens with *"Operational troubleshooting"*, does not look like it applies when the run just succeeded.

## Changes

**1. Trigger on verification.** Reframed around *"anything you do after a message enters a running production"*, with verification named first. The description and both router entries now say explicitly that checking a run that **worked** counts. The router row also names the concrete moment it should fire: *load it before writing any query against `Ens.MessageHeader` / `Ens_Util.Log`*.

**2. `Where raw SQL IS the right answer`.** The old rule was absolute — *"do not hand-write SQL against `Ens_Util.Log` / `Ens.MessageHeader`"* — and it is wrong for ~10% of real cases: `iris_interop_query` returns header rows, so it cannot aggregate and cannot join to the message body. **A rule that is wrong sometimes gets discarded always.** Naming the three legitimate cases (`GROUP BY` counts, error counts by component, join-to-body for business fields) is what makes the other 90% enforceable.

**3. Headless resend.** `iris_interop_query` has no resend mode (`what` accepts only `logs`/`queues`/`messages`/`trace`/`partners`), and the skill previously described only the Portal route:

```objectscript
Set newId = "", sc = ##class(Ens.MessageHeader).ResendDuplicatedMessage(<headerId>, .newId)
```

Verified on IRIS 2026.1 via `iris_execute`: header `102` returned `$$$OK` with `newId = 171`, and the new session appeared in `Ens.MessageHeader` immediately.

It also warns that `docs_introspect` returns an empty `{"methods":[],"properties":[],"success":true}` for that member — which reads as *"no such method"*. The one student who resent successfully got the signature from elsewhere **after** that empty answer; the skill should not let the next person conclude the method doesn't exist.

## Note on the one student who got it right

19 of his 20 message-search calls succeeded first try, using four of the five `what` modes plus `since_id` and `component` — **without ever loading this skill**. His only failure was `SELECT … FROM Ens_Util.Statistics`, a table that does not exist. His hand SQL was the legitimate kind: aggregates and a join to the body class. That is the shape of usage this PR is trying to make reproducible rather than exceptional.

For the record, `iris_interop_query` itself is solid: across the entire cohort it returned an error **once**, for a missing `what`. The problem was never the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)