### PR TITLE
feat(gate): block interop MCP calls that omit namespace, and say so up front

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -12,7 +12,7 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "mcp__.*__iris_doc|iris_doc|mcp__.*__iris_compile|iris_compile|mcp__.*__iris_execute|iris_execute",
+        "matcher": "mcp__.*__iris_doc|iris_doc|mcp__.*__iris_compile|iris_compile|mcp__.*__iris_execute|iris_execute|mcp__.*__iris_production|iris_production|mcp__.*__iris_production_item|iris_production_item|mcp__.*__iris_credential_list|iris_credential_list|mcp__.*__iris_credential_manage|iris_credential_manage|mcp__.*__iris_lookup_manage|iris_lookup_manage|mcp__.*__iris_lookup_transfer|iris_lookup_transfer",
         "hooks": [
           {
             "type": "command",

--- a/hooks/interop_bootstrap.py
+++ b/hooks/interop_bootstrap.py
@@ -21,7 +21,11 @@ MSG = (
     "(4) reach IRIS ONLY through the MCP (iris_doc/iris_compile/iris_test) — never iris.exe / "
     "iris session / $SYSTEM.OBJ.Load / $SYSTEM.OBJ.Compile; "
     "(5) TDD: a component is done only when its %UnitTest.TestProduction actually runs GREEN via "
-    "iris_test (NO_TESTS_FOUND means compile the test first and pass the exact class name)."
+    "iris_test (NO_TESTS_FOUND means compile the test first and pass the exact class name); "
+    "(6) ALWAYS pass namespace= to iris_production / iris_production_item / iris_credential_* / "
+    "iris_lookup_* — it is documented as optional but omitting it fails ~95% of the time, with an "
+    "internal error that never names the cause (<CLASS DOES NOT EXIST> Ens.Director, or Table "
+    "'ENS_CONFIG.CREDENTIALS' not found). check_config lists the namespaces on this connection."
 )
 
 

--- a/hooks/interop_conformance_gate.py
+++ b/hooks/interop_conformance_gate.py
@@ -36,6 +36,26 @@ BS_BO_SEGS = {"BS", "BO", "Service", "Operation", "BusinessService", "BusinessOp
 # for Load*/Import*/Compile* only — Delete/DeletePackage/Export are intentionally NOT matched.
 OBJ_BYPASS = re.compile(r"(?i)SYSTEM\.OBJ\)?\.(Load|Import|Compile)")
 
+# Tools whose `namespace` is documented as OPTIONAL but is effectively REQUIRED: they resolve
+# Ens.Director / Ens_Config.* in whatever namespace the connection defaults to, and if that one
+# is not interop-enabled the call dies with an internal error that never names the cause
+# (`<CLASS DOES NOT EXIST> Ens.Director`, `Table 'ENS_CONFIG.CREDENTIALS' not found`).
+#
+# Measured over a full workshop cohort (18 students, 15,079 tool calls): omitting `namespace`
+# on these failed 37 of 39 times (95%), against 16% when it was passed.
+#     iris_credential_list   14/14 failed      iris_production_item   7/7 failed
+#     iris_production        15/17 failed      iris_lookup_manage      1/1 failed
+#
+# Deliberately NOT listed, because the same capture proves they are fine without it:
+# `check_config` (0/41 failures) and `iris_get_log` (0/40). A blanket rule would be wrong.
+# Also not listed: iris_doc / iris_compile / iris_query / iris_execute / iris_test /
+# iris_interop_query — every observed call already passed `namespace`, so there is no evidence
+# either way and the gate does not guess.
+NS_REQUIRED = {
+    "iris_production", "iris_production_item", "iris_credential_list",
+    "iris_credential_manage", "iris_lookup_manage", "iris_lookup_transfer",
+}
+
 
 def deny(reason):
     print(json.dumps({"hookSpecificOutput": {
@@ -67,6 +87,22 @@ def main():
     ti = data.get("tool_input", {}) or {}
     names = collect_names(ti)
     content = ti.get("content") if isinstance(ti.get("content"), str) else ""
+
+    # (4) interop tool called without `namespace` — 95% of these fail, and the error that comes
+    # back names Ens.Director or a missing ENS_* table instead of the namespace. Cheaper to stop
+    # here: adding an explicit namespace is never wrong, so a false positive costs one parameter.
+    tool = str(data.get("tool_name") or "").split("__")[-1]
+    if tool in NS_REQUIRED and not ti.get("namespace"):
+        deny(
+            "`" + tool + "` was called without `namespace`. The parameter is documented as optional, "
+            "but it resolves Ens.Director / Ens_Config.* in the connection's default namespace — and "
+            "when that one is not interop-enabled the call fails with an internal error that never "
+            "names the cause (`<CLASS DOES NOT EXIST> Ens.Director`, `Table 'ENS_CONFIG.CREDENTIALS' "
+            "not found`). Measured over a workshop cohort: 37 of 39 such calls failed (95 percent), "
+            "against 16 percent when namespace was passed. Retry with the production's namespace, "
+            "e.g. `" + tool + "(namespace=\"<NS>\", ...)`. `check_config` lists the namespaces "
+            "available on this connection."
+        )
 
     # (3) iris_execute used to load/compile/import classes — bypasses iris_doc/iris_compile + this gate.
     code = ti.get("code") if isinstance(ti.get("code"), str) else ""

--- a/skills/message-search-debug/SKILL.md
+++ b/skills/message-search-debug/SKILL.md
@@ -36,6 +36,15 @@ When inspecting a running production through the IRIS MCP, reach for `iris_inter
 
 > **The `<SYNTAX>errdone+2^%qaqqt` signature = you hand-rolled SQL through `iris_execute`.** `%qaqqt` is the SQL query compiler; it chokes on malformed/dynamic SQL (invalid predicates like `%STARTSWITH`/`%LIKE`, or `SELECT … FROM` a table that doesn't exist — `Ens_Config.Setting`, `Config.config`, `%SYS.*ELS*`). Two fixes: (1) a read-only SELECT → use `iris_query` (it goes through a real result-set path and returns a `hint` naming the right typed tool on "table not found"); (2) anything that runs ObjectScript or **generates classes** → wrap it in a `[SqlProc]` class method and call it via `iris_query`, never embed `&sql`/`%SQL.Statement` inside an `iris_execute` snippet.
 
+> **Always pass `namespace`.** It is documented as optional on these tools and it is not: it
+> resolves `Ens.Director` / `Ens_Config.*` in whatever namespace the connection defaults to, and if
+> that one is not interop-enabled the call dies with an error that never names the cause —
+> `<CLASS DOES NOT EXIST> Ens.Director`, or `Table 'ENS_CONFIG.CREDENTIALS' not found`. Measured over
+> a workshop cohort: **omitting it failed 37 of 39 times (95%)**, against 16% when it was passed
+> (`iris_credential_list` 14/14, `iris_production_item` 7/7, `iris_production` 15/17). The PreToolUse
+> gate now blocks these calls when `namespace` is missing. Exceptions, verified: `check_config` and
+> `iris_get_log` work fine without it.
+
 | You want… | Call this (one round-trip) |
 |---|---|
 | Event Log of a component | `iris_interop_query(what=logs, component="<Item>")` |


### PR DESCRIPTION
## The problem

`namespace` is documented as **optional** on the interop MCP tools. It is effectively **required**. Measured over a full workshop cohort — 18 students, 15,079 tool calls:

| | calls | failures |
|---|---|---|
| **with** `namespace` | 1,129 | 180 (**16%**) |
| **without** `namespace` | 39 | **37 (95%)** |

| Tool | without `namespace` |
|---|---|
| `iris_credential_list` | **14/14 failed** |
| `iris_production_item` | **7/7 failed** |
| `iris_production` | 15/17 failed |
| `iris_lookup_manage` | 1/1 failed |

And the failures are undiagnosable. All 37 come back as `<CLASS DOES NOT EXIST> Ens.*` (×22) or `Table 'ENS_*' not found` (×14) — internal errors from resolving `Ens.Director` / `Ens_Config.*` in whatever namespace the connection defaults to:

```jsonc
iris_credential_list()          // no arguments
-> {"error": "ERROR #5540: SQLCODE: -30 Message: Table 'ENS_CONFIG.CREDENTIALS' not found", …}

iris_production_item(action: "get_settings", item: "BO.MenusJDBC", production: "Ejercicio3.Production")
-> {"error": "ERROR: <CLASS DOES NOT EXIST> … Ens.Director", …}
```

Nothing says *"this namespace has no interoperability, pass `namespace=`"*. A reader concludes `Ens.Director` is missing or the credentials table was never created. Neither is true.

## Three layers

The model needs the rule at three different moments, so it is stated three times:

1. **SessionStart bootstrap** — convention (6). In context from turn zero, before any tool call happens.
2. **`message-search-debug`** — the typed-call table now leads with it, including the numbers and the verified exceptions.
3. **PreToolUse gate — DENY.** This is the layer that actually saves the round trip.

On the deny being the right call: **adding an explicit namespace is never wrong.** A false positive costs one parameter; a false negative costs a cryptic failure 95% of the time. That asymmetry is what justifies blocking rather than advising.

## Scope is evidence-bound, not a blanket rule

**Gated**: `iris_production`, `iris_production_item`, `iris_credential_list`, `iris_credential_manage`, `iris_lookup_manage`, `iris_lookup_transfer`.

**Deliberately not gated**, because the same capture proves they are fine without it:

- `check_config` — 0/41 failures bare
- `iris_get_log` — 0/40 failures bare

**Also not gated**: `iris_doc` / `iris_compile` / `iris_query` / `iris_execute` / `iris_test` / `iris_interop_query`. Every observed call already passed `namespace`, so there is no evidence either way and the gate does not guess.

## Verification

Against the real hook via stdin — **15 cases, 0 failures**:

- each gated tool without `namespace` → deny; with `namespace` → allow
- `iris_get_log` and `check_config` bare → allow
- the three pre-existing checks (naming convention, adapter-as-superclass, `$SYSTEM.OBJ` smuggled through `iris_execute`) still fire, and still stay silent on conformant input

## Relationship to the MCP

Filed as intersystems-ib/iris-interop-dev#5. The durable fix belongs there — a `NAMESPACE_NOT_INTEROP` code with a `hint` naming the parameter, which would turn 37 dead ends into one corrected retry. This gate is the client-side guard until that lands, and remains useful afterwards by preventing the call rather than explaining it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)