### PR TITLE
fix(skills): three compile failures the cohort hit that no skill covered

### DIFF
--- a/skills/bpl/SKILL.md
+++ b/skills/bpl/SKILL.md
@@ -93,6 +93,28 @@ When a single origin needs to fan out to multiple destinations (e.g. CSV → Pos
 
 **Anti-pattern**: splitting into one rule per destination ("CSV-to-SQL", "CSV-to-SOAP", "CSV-to-REST") to "isolate failures". That conflates *runtime fault tolerance* with *architecture*; it multiplies rules, makes routing harder to reason about, and the symptom it's trying to fix — a missing transform class or target BO — is a **development error** caught much earlier by a pre-flight validator (below), not by rule fragmentation.
 
+### What a `condition=` can and cannot contain
+
+The rule XData is compiled into `evaluateRuleDefinition` by a code generator. The condition language
+is **not ObjectScript**, and the generator reports offsets into *generated* code, so the message never
+points at what you actually wrote:
+
+```
+ERROR <Ens>ErrInvalidName: Invalid name at offset 1
+ERROR <Ens>ErrInvalidToken: Invalid token at offset 21
+  > ERROR #5490: Error running generator for method 'evaluateRuleDefinition:MyApp.RUL.Router'
+```
+
+| Don't write this in a condition | Write this instead |
+|---|---|
+| `##class(MyApp.UTL.Validar).EsValido(Document)=1` | put the method in an **`Ens.Rule.FunctionSet` subclass** and call it bare, by name: `EsValido(Document)=1` |
+| `Document.Planta '= ""` — ObjectScript's "not equal" | `Document.Planta != ""` |
+| `document.Planta` on an `EnsLib.MsgRouter.RoutingEngine` | `Document.Planta` — **capitalised**; the lowercase form doesn't resolve |
+
+Once the FunctionSet class exists in the namespace, its methods are offered by name in the rule editor
+and accepted in the XData. Measured over a workshop cohort: **12 of 18 students** hit `#5490` on a
+routing rule, all of it on these three shapes.
+
 ### Pre-flight validator for missing classes / targets
 
 When a `<send transform="X" target="Y"/>` references a class or item that doesn't exist, the BP terminates at runtime with `<CLASS DOES NOT EXIST>` or `target 'Y' not an item`. The remedy is a **validator invoked before production start** that parses the rule's XData and checks each `transform=` and `target=` against the dictionary and the production's item list. A canonical SqlProc:

--- a/skills/business-services/SKILL.md
+++ b/skills/business-services/SKILL.md
@@ -52,6 +52,27 @@ Method OnProcessInput(pInput As EnsLib.RecordMap.Base, Output pOutput As %Regist
 }
 ```
 
+### `OnProcessInput`'s signature is fixed by the base class — there is not one shape
+
+The skeleton above is the **RecordMap / File** shape. Other base classes require a different argument
+list, and the compiler rejects anything else outright:
+
+```
+ERROR #5478: Keyword signature error in MyApp.BS.PacientesREST:Method:OnProcessInput,
+keyword 'method argument/s signature' must be
+'%Library.RegisteredObject,%Library.RegisteredObject,%Library.String' or its subclass
+  > ERROR #5030: An error occurred while compiling class 'MyApp.BS.PacientesREST'
+```
+
+Read that message literally: it **states the exact signature required** and is the authoritative answer
+for that superclass — match it instead of reasoning about what the arguments ought to be. Types may be
+narrowed to a subclass (`pInput As EnsLib.RecordMap.Base` in a `%RegisteredObject` slot), but the
+**arity cannot change**.
+
+Measured over a workshop cohort: **8 of 18 students** hit `#5478`, mostly by carrying the two-argument
+RecordMap shape onto a REST or HTTP service. When unsure, `docs_introspect` the base class's
+`OnProcessInput` before writing the override.
+
 ## Production naming — `Tipo.Nombre`
 
 Every BS/BO/Router/Util item has a name in the production XML. Use the convention `<Type>.<Name>` consistently across the production:

--- a/skills/transformations/SKILL.md
+++ b/skills/transformations/SKILL.md
@@ -126,6 +126,37 @@ When transforming CDA documents (HL7 CDA R2 XML), DTL is awkward because of deep
 
 In those cases either embed a single `code` action that calls a class method, or replace the DTL with a method on a BP.
 
+### ObjectScript inside XData is XML text — escape it
+
+A DTL lives in an `XData` block, so everything inside `<code>`, `<assign value=…>` and
+`<if condition=…>` is parsed as **XML first, ObjectScript second**. The operators that collide are
+exactly the ones ObjectScript uses most:
+
+| ObjectScript | Inside XData |
+|---|---|
+| `&&` | `&amp;&amp;` |
+| `&` | `&amp;` |
+| `<`, `<=` | `&lt;`, `&lt;=` |
+| `>` | `&gt;` (required inside attribute values) |
+
+```xml
+<!-- breaks: ERROR #6301 SAX XML Parser Error: expected entity name for reference -->
+<code>Quit:(tipo="")&&(val="")</code>
+
+<!-- works -->
+<code>Quit:(tipo="")&amp;&amp;(val="")</code>
+
+<!-- or wrap it, which survives copy-paste and later edits better -->
+<code><![CDATA[Quit:(tipo="")&&(val="")]]></code>
+```
+
+**`expected entity name for reference` always means an unescaped `&`.** The parser reports a line and
+offset **into the XData stream**, not into your source file, so the numbers will not match your editor
+— go looking for the `&`, not for line 10. Measured over a workshop cohort: **16 of 18 students** hit
+`#6301`.
+
+The same rule governs routing-rule XData and any hand-written `XData ProductionDefinition` — see `bpl`.
+
 ## Where per-record validation belongs — the DTL, with `Valido`/`ErrorMotivo` flags
 
 When an inbound flow must **validate each record and route valid vs invalid differently** (persist the good ones, send the bad ones to an error folder + alert), put the validation **in the DTL**, writing the outcome onto the target message as two properties — `Valido` (`%Boolean`) and `ErrorMotivo` (`%String`) — rather than failing the transform.


### PR DESCRIPTION
Mined from the finished workshop — **18 students, 15,079 tool calls, 160 sessions**. Ranked by how many students hit each, these were the top skill-fixable compile errors, and **none of the three was documented anywhere**.

## 1. `transformations` — ObjectScript inside XData is XML text · **16 of 18 students**

```
ERROR #6301: SAX XML Parser Error: expected entity name for reference
```

A DTL lives in an `XData` block, so `<code>`, `<assign value=…>` and `<if condition=…>` are parsed as **XML first, ObjectScript second**. The colliding operators are the ones ObjectScript uses most. Confirmed cause, verbatim from a failing class:

```xml
<code>Quit:(tipo="")&&(val="")</code>
```

That message **always** means an unescaped `&`. The line and offset it reports are into the *XData stream*, not the source file — so the number never matches the editor and people go hunting in the wrong place. Added: the escape table (`&&`→`&amp;&amp;`, `&`, `<`, `>`), the CDATA alternative, and a pointer from `bpl` since rule XData has the identical problem.

## 2. `bpl` — what a rule `condition=` may contain · **12 of 18 students**

```
ERROR <Ens>ErrInvalidName: Invalid name at offset 1
ERROR <Ens>ErrInvalidToken: Invalid token at offset 21
  > ERROR #5490: Error running generator for method 'evaluateRuleDefinition:MyApp.RUL.Router'
```

The condition language is **not ObjectScript**, and the generator reports offsets into *generated* code, so the message never points at what was written. Three shapes fail:

| Don't | Do |
|---|---|
| `##class(MyApp.UTL.Validar).EsValido(Document)=1` | put it in an `Ens.Rule.FunctionSet` and call it bare: `EsValido(Document)=1` |
| `Document.Planta '= ""` | `Document.Planta != ""` |
| `document.Planta` | `Document.Planta` — capitalised |

All three were already solved and written down in a reference project's notes. None had reached a skill.

## 3. `business-services` — `OnProcessInput`'s signature is fixed by the base class · **8 of 18**

```
ERROR #5478: Keyword signature error in MyApp.BS.PacientesREST:Method:OnProcessInput,
keyword 'method argument/s signature' must be
'%Library.RegisteredObject,%Library.RegisteredObject,%Library.String' or its subclass
```

The skill's canonical BS shows the **two-argument RecordMap shape as if it were universal**; a REST service needs three. The compiler states the required signature verbatim, which makes it the authoritative answer — the skill now says to read it literally rather than reason about the arguments, and to `docs_introspect` the base class when unsure.

## Explicitly not added

- `ERROR #5001` is mostly the exercise **behaving as designed** — a fixture date of `32/13/1990` that the flow is supposed to reject — plus a `MAXLEN` violation `messages` already covers.
- 54 of the 120 tool rejections were `Bash` and 19 `Read`: student permission friction, not skill failure.

## Verification

The three XML snippets in the escaping section behave exactly as documented — the "breaks" one fails to parse, both "works" forms parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)