### PR TITLE
fix(unit-tests): the shipped SqlProc runner reports a crashed test as PASSED

### DIFF
--- a/skills/conformance-review/SKILL.md
+++ b/skills/conformance-review/SKILL.md
@@ -15,6 +15,13 @@ re-plan from scratch and it never rewrites silently.
 > not a `%UnitTest` result. The review MUST re-run the real `iris_test` tool against the
 > `%UnitTest.TestProduction` class and confirm genuine asserts pass before trusting any "tests green"
 > claim (see CR-7). If `iris_test` itself errors, that is a finding, not a pass.
+>
+> This is stronger than "don't mark your own homework": such a runner has a failure mode it **cannot
+> detect by construction**. A test method that raises before its first `$$$Assert*` writes **zero assert
+> rows**, so any "did any assert fail?" scan finds nothing and counts the method as passed. Measured on
+> IRIS for Health 2026.1: on a class where `%UnitTest` printed `**FAILED**` and `iris_test` reported red,
+> an assert-scanning wrapper reported `passed=2 failed=0`. See `unit-tests` for the fix if you must keep
+> such a wrapper — read the **method node's** own flag, never its assert children.
 
 ## How to run a review
 

--- a/skills/unit-tests/SKILL.md
+++ b/skills/unit-tests/SKILL.md
@@ -48,12 +48,32 @@ Avoid the documentation-default `RunTest` invocation that loads from `^UnitTestR
 |---|---|
 | **`do ##class(MyApp.Tests.X).Run()`** | Default for Interop work. Same-process, returns a status, no docker exec required. No load/delete of test source — but still requires `^UnitTestRoot` set to an existing dir (see above). |
 | **`do ##class(%UnitTest.Manager).DebugRunTestCase("", "MyApp.Tests.X", "/noload/norecursive/nodelete")`** | When you need the manager's full lifecycle (suite tracking, log granularity) but not its load-and-delete behaviour. Use **boolean qualifiers** only (see pitfall below). |
-| **SqlProc wrapper around `DebugRunTestCase` invoked via `iris_query`** | MCP-friendly path when `iris_test` isn't available (it requires `IRIS_CONTAINER` / docker exec — fails on Windows-host IRIS). See the wrapper template below. |
+| **SqlProc wrapper around `DebugRunTestCase` invoked via `iris_query`** | **Legacy fallback only** — see the warning below. `iris_test` runs over HTTP and needs no container; prefer it whenever the MCP is present. |
 | **`%UnitTest.Portal` UI** | Visual, navigable; for inspecting results, not driving runs. |
 
-### MCP-friendly runner: the SqlProc wrapper
+### The SqlProc wrapper — legacy fallback, and how it silently lies
 
-When driving IRIS from MCP, wrap `DebugRunTestCase` in a SqlProc the bootstrap class exposes, then call via `iris_query`:
+> **Prefer `iris_test`.** This wrapper existed because `iris_test` used to require `IRIS_CONTAINER` /
+> docker exec. It no longer does — it works over HTTP against a Windows-host IRIS. `conformance-review`
+> **CR-7 flags a `[SqlProc]`-returned "PASS" as unverified**, and the reason is below.
+
+**A runner that counts assert rows cannot detect a test that crashed.** If a method raises before its
+first `$$$Assert*` — an `<UNDEFINED>` on an uninitialised variable is the common case — it writes **zero
+assert rows**. A loop that scans the asserts looking for a failure finds none, and counts the method as
+**passed**. Verified on IRIS for Health 2026.1:
+
+```
+LogStateStatus:0:TestRevienta: ERROR #5002: <UNDEFINED>… <<==== **FAILED**
+TestRevienta failed
+…
+passed=2 failed=0          ← what an assert-counting wrapper reported for that same run
+```
+
+The framework itself is right — `%UnitTest` records the method as failed and `iris_test` reports it red.
+Only the hand-rolled summary is wrong.
+
+**The fix is to read the method node's own verdict**, not its assert children. `$LISTGET(node,1)` is the
+framework's own pass/fail flag and it is already correct for both failure modes:
 
 ```objectscript
 ClassMethod RunTestClass(pClassName As %String) As %String [ SqlProc ]
@@ -69,9 +89,10 @@ ClassMethod RunTestClass(pClassName As %String) As %String [ SqlProc ]
         Set m = ""
         For {
             Set m = $O(^UnitTest.Result(resultId, suite, pClassName, m))  Quit:m=""
-            Set ok = 1, s = ""
-            For { Set s = $O(^UnitTest.Result(resultId, suite, pClassName, m, s))  Quit:s=""
-                  If $LISTGET($G(^UnitTest.Result(resultId, suite, pClassName, m, s)), 1) = 0 Set ok = 0 }
+            // The METHOD node carries the framework's own verdict. Do NOT scan the assert
+            // children: a method that crashed before its first assert has none, and an
+            // "any child failed?" loop then reports it as passed.
+            Set ok = +$LISTGET($G(^UnitTest.Result(resultId, suite, pClassName, m)), 1)
             If ok { Set passed = passed + 1 }
             Else  { Set failed = failed + 1, failedList = failedList _ $S(failedList="":"", 1:", ") _ m }
         }
@@ -79,6 +100,10 @@ ClassMethod RunTestClass(pClassName As %String) As %String [ SqlProc ]
     Quit "passed="_passed_" failed="_failed_$S(failed>0:" | failures: "_failedList, 1:"")_" | rid="_resultId
 }
 ```
+
+Verified on IRIS for Health 2026.1 against a class with one passing method, one failing assert and one
+`<UNDEFINED>` crash: `passed=1 failed=2 | failures: TestAssertFalla, TestRevienta`. The previous
+assert-scanning form reported `passed=2 failed=0` on the same class.
 
 Invoke from MCP:
 
@@ -142,7 +167,9 @@ Results land in:
 - `success` is `1` for pass, `0` for fail.
 - `description` is the assert message.
 
-The SqlProc wrapper above traverses this global to compute the pass/fail summary. The portal renders the same data graphically.
+The SqlProc wrapper above traverses this global to compute the pass/fail summary — reading each
+**method node's** own flag, not its assert children, for the reason given in that section. The portal
+renders the same data graphically.
 
 ## Error handling inside test methods
 


### PR DESCRIPTION
## The bug is in this repo's own example

The runner published in `unit-tests` scans each method's **assert children** and marks the method failed only if one of them failed:

```objectscript
Set ok = 1, s = ""
For { Set s = $O(^UnitTest.Result(resultId, suite, pClassName, m, s))  Quit:s=""
      If $LISTGET($G(^UnitTest.Result(resultId, suite, pClassName, m, s)), 1) = 0 Set ok = 0 }
If ok { Set passed = passed + 1 }
```

A test method that raises **before its first `$$$Assert*`** writes **zero assert rows**. The loop body never executes, `ok` stays `1`, and the method is counted as **passed**.

So the skill was shipping the exact anti-pattern `conformance-review` **CR-7 flags as P0**.

## Reproduced, running the skill's code verbatim

IRIS for Health 2026.1, a class with one passing method and one that raises `<UNDEFINED>` before asserting:

```
LogStateStatus:0:TestRevienta: ERROR #5002: <UNDEFINED>… <<==== **FAILED**
TestRevienta failed
TmpProbe.AssertBlind failed
Some tests FAILED in suites
...
passed=2 failed=0        ← the skill's runner, on that same run
```

**The framework is not at fault.** `%UnitTest` records `TestRevienta` with `Status=0`, the case fails, the suite fails, and `iris_test` reports it red. Only the hand-rolled summary lies.

| method | `TestMethod.Status` | assert rows |
|---|---|---|
| `TestBien` | 1 | 2 |
| `TestRevienta` | **0** | **0** |

## The fix

Read the **method node's own verdict** — `$LISTGET(node,1)` — instead of its assert children. It is the framework's own flag and is already correct for both failure modes.

Verified against a class with one passing method, one failing assert, and one crash:

| | result |
|---|---|
| corrected runner | `passed=1 failed=2 \| failures: TestAssertFalla, TestRevienta` |
| previous runner | `passed=2 failed=0` |

## Also: the reason the wrapper existed is stale

It was documented as *"MCP-friendly path when `iris_test` isn't available (it requires `IRIS_CONTAINER` / docker exec — fails on Windows-host IRIS)"*. That has not been true for some time — `iris_test` runs over HTTP against a Windows-host IRIS, and a full workshop cohort made **376 `iris_test` calls** on exactly that setup. The wrapper is now labelled a legacy fallback that points at `iris_test` first.

## `conformance-review`

CR-7's rationale gains the structural argument: the case for `iris_test` is not merely *"don't mark your own homework"* — an assert-scanning runner has a failure mode it **cannot detect by construction**, because there is nothing to scan.

Closes the open question in #14, which was filed noting the framework side was unverified. It is now verified: `%UnitTest` and `iris_test` are correct, and the bug was ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)