### PR TITLE
fix(tdd): the TDD guard never fired, and green-on-first-run went unnoticed

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -32,7 +32,7 @@
         ]
       },
       {
-        "matcher": "Write|Edit",
+        "matcher": "Write|Edit|mcp__.*__iris_doc|iris_doc",
         "hooks": [
           {
             "type": "command",
@@ -50,6 +50,15 @@
           {
             "type": "command",
             "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/docker-detect.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "mcp__.*__iris_test|iris_test",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/tdd-first-green.sh"
           }
         ]
       }

--- a/hooks/tdd-first-green.sh
+++ b/hooks/tdd-first-green.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# PostToolUse test-after detector (iris-interop-skills) — flags a test class whose FIRST
+# run is green, which means it was written against code that already existed.
+# Thin wrapper: exec the .py so the hook JSON on stdin reaches Python. Resolves the
+# interpreter as python3 -> python -> py (Windows has no real `python3`, only a Store stub that must be rejected); no-op if none is
+# on PATH. Never blocks.
+PY=
+for _cand in python3 python py; do
+    _path=$(command -v "$_cand" 2>/dev/null) || continue
+    # Being on PATH is not the same as working. Windows ships a 0-byte Microsoft Store
+    # stub named python3.exe in %LOCALAPPDATA%\Microsoft\WindowsApps: `command -v` finds
+    # it, exec'ing it prints "Python was not found" and exits non-zero. Taking the first
+    # name that resolves made every hook fail on a machine that had a perfectly good
+    # python.exe one PATH entry away. Run the candidate before trusting it.
+    "$_path" -c '' >/dev/null 2>&1 || continue
+    PY=$_path
+    break
+done
+[ -n "$PY" ] || exit 0
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "$PY" "$DIR/tdd_first_green.py"

--- a/hooks/tdd_enforcement.py
+++ b/hooks/tdd_enforcement.py
@@ -1,12 +1,36 @@
 #!/usr/bin/env python3
-"""PostToolUse TDD guard for Write|Edit (iris-interop-skills).
+"""PostToolUse TDD guard for Write|Edit and iris_doc (iris-interop-skills).
 
-If an interop implementation class (*.BO.* / *.BP.* / *DTL* / *Rule* ending .cls) is
-written WITHOUT a sibling *Test* class nearby, remind the model to write the test first
-(spec -> test -> red -> implement -> green; tests extend %UnitTest.TestProduction).
-Advisory only; filesystem heuristic; never blocks.
+If an interop implementation class (BS/BP/BO/DT/DTS/RUL, DTL, Rule) is written WITHOUT a
+test for it, remind the model to write the test first (spec -> test -> red -> implement ->
+green; tests extend %UnitTest.TestProduction). Advisory only; never blocks.
+
+Two things this has to get right, both learned from a workshop cohort where it fired zero
+times across 18 students and 567 component classes:
+
+  1. The component detector must accept BOTH shapes of name. The class is `Pkg.BO.Name`
+     but the FILE is `src/Pkg/BO/Name.cls` — the `interop` skill mandates the Atelier
+     nested layout, so the path carries directory separators, not dots. A detector written
+     as `\\.bo\\.` matches only the flat-dotted form that same skill tells you not to use.
+  2. It must cover the tools actually used. Classes reach IRIS either as a file
+     (Write/Edit) or straight through `iris_doc(mode=put)`; watching only the first misses
+     everything written directly to the namespace.
 """
 import sys, json, os, re, glob
+
+# Type segment delimited by a dot OR a path separator: matches `Pkg.BO.Name` and
+# `src/Pkg/BO/Name.cls` alike. DTS/DT/RUL/BS included — the old pattern had neither
+# `dt` nor `rul`, so transforms and rules were invisible even in flat-dotted form.
+COMPONENT = re.compile(r"[./\\](?:BS|BP|BO|DT|DTS|RUL)[./\\]|DTL|Rule", re.I)
+
+
+def component_name(ti):
+    """The class or file this call is writing, or '' if it isn't a class write."""
+    # iris_doc(mode=put, name="Pkg.BO.Name.cls")
+    if ti.get("mode") == "put" and isinstance(ti.get("name"), str):
+        return ti["name"]
+    path = ti.get("file_path") or ti.get("path") or ""
+    return path if str(path).lower().endswith(".cls") else ""
 
 
 def main():
@@ -14,34 +38,33 @@ def main():
         data = json.load(sys.stdin)
     except Exception:
         return
-    ti = data.get("tool_input", {})
-    path = ti.get("file_path") or ti.get("path") or ""
-    low = path.lower()
-    if not low.endswith(".cls"):
+    ti = data.get("tool_input", {}) or {}
+    target = component_name(ti)
+    if not target or not COMPONENT.search(target):
         return
-    if not re.search(r"\.bo\.|\.bp\.|dtl|rule", low):  # interop component classes only
-        return
-    base = os.path.basename(path)
+    base = os.path.basename(str(target).replace("\\", "/"))
     if "test" in base.lower():  # the test itself — fine
         return
 
+    # A test anywhere in the project counts. Deliberately loose: the goal is to nudge when
+    # there is NO test at all, not to police naming.
     roots = []
-    d = os.path.dirname(path)
-    if d:
+    d = os.path.dirname(str(target).replace("\\", "/"))
+    if d and os.path.isdir(d):
         roots.append(d)
     proj = os.environ.get("CLAUDE_PROJECT_DIR")
     if proj:
         roots.append(proj)
-
     for r in roots:
         if r and glob.glob(os.path.join(r, "**", "*Test*.cls"), recursive=True):
-            return  # a test exists nearby
+            return
 
     msg = (
-        "TDD: you just wrote an interop component (" + base + ") but found no sibling "
-        "*Test*.cls. Per iris-interop-skills:tdd, write the test FIRST "
-        "(spec -> test -> red -> implement -> green). Test classes extend "
-        "%UnitTest.TestProduction."
+        "TDD: you just wrote the interop component " + base + " and no *Test*.cls exists "
+        "for it. Per iris-interop-skills:tdd the order is spec -> test -> RED -> implement "
+        "-> green: write the test first and SEE IT FAIL, so it tests the spec rather than "
+        "the code you already wrote. Test classes extend %UnitTest.TestProduction. "
+        "A component is not done until iris_test returns green on a test that was red before."
     )
     print(json.dumps({"hookSpecificOutput": {
         "hookEventName": "PostToolUse", "additionalContext": msg}}))

--- a/hooks/tdd_first_green.py
+++ b/hooks/tdd_first_green.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""PostToolUse detector for test-after-code (iris-interop-skills).
+
+TDD's invariant is not "there is a test" — it is "the test failed before the code made it
+pass". A test class whose FIRST EVER run is green was written against code that already
+existed, so its assertions describe current behaviour instead of the specification. That is
+the mechanism behind shallow tests, and it is invisible to any count of assertions.
+
+Measured over a workshop cohort: 67 of 103 test classes (65%) were green on their first
+run, while assertion density was healthy (5.3 Test* methods per class, 2.8 asserts each).
+Prescribing "more assertions" would have missed the problem entirely.
+
+Keeps a per-project ledger of which test classes have already run, so "first" means first
+in the project, not first in the session. Advisory only; never blocks.
+"""
+import sys, json, os, re, hashlib
+
+LEDGER = ".claude/.iris-interop-tdd-seen"
+
+
+def ledger_path():
+    proj = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+    return os.path.join(proj, LEDGER)
+
+
+def seen(key):
+    """True if this test class has run before; records it either way."""
+    p = ledger_path()
+    tag = hashlib.sha1(key.encode("utf-8", "replace")).hexdigest()[:16]
+    try:
+        if os.path.isfile(p):
+            with open(p, "r", encoding="utf-8", errors="replace") as f:
+                if tag in f.read().split():
+                    return True
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "a", encoding="utf-8") as f:
+            f.write(tag + "\n")
+    except Exception:
+        return True  # never nag on a ledger problem
+    return False
+
+
+def outcome_is_green(payload):
+    if not isinstance(payload, dict):
+        return None
+    if "outcome" in payload:
+        return payload.get("outcome") == "passed" or bool(payload.get("success"))
+    if "success" in payload:
+        return bool(payload["success"])
+    return None
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return
+    ti = data.get("tool_input", {}) or {}
+    target = ti.get("pattern") or ti.get("class") or ti.get("target") or ""
+    if not isinstance(target, str) or not target.strip():
+        return
+
+    raw = data.get("tool_response", data.get("tool_result", ""))
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except Exception:
+            raw = {}
+    green = outcome_is_green(raw)
+    if green is not True:
+        return  # red, or unparseable — nothing to say; red is what we want
+
+    if seen(target.strip()):
+        return  # ran before; a later green is just the normal cycle
+
+    msg = (
+        "TDD check: `" + target.strip() + "` passed on its FIRST run. In spec -> test -> RED "
+        "-> implement -> green, the first run is red — a test that is green immediately was "
+        "written against code that already existed, so it encodes current behaviour rather "
+        "than the specification. Before calling this component done, add at least one case "
+        "that FAILS against the implementation as it stands right now: a rejected input for "
+        "each validation rule in the spec, the boundary values, and the malformed-input "
+        "fixtures. If nothing you can write fails, the test is not yet testing the spec. "
+        "See iris-interop-skills:tdd, 'How much test is enough'."
+    )
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PostToolUse", "additionalContext": msg}}))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -77,6 +77,44 @@ Stepping over 1-2-3 ("just write the DTL first") is the most common anti-pattern
 
 > "I'll write the test first. It defines what 'done' means, and we'll know we're done when it passes."
 
+### Step 3 is the load-bearing one — a test that never went red proves nothing
+
+**If the first run of a test class is green, TDD did not happen.** The test was written against
+code that already existed, so its assertions describe what the code *does* rather than what the
+spec *requires* — and a bug in the code gets faithfully encoded as the expected result. No count
+of assertions can detect this.
+
+Measured over a workshop cohort: **67 of 103 test classes (65%) were green on their first ever
+run**, while assertion density looked perfectly healthy — 5.3 `Test*` methods per class, 2.8
+asserts per method. The tests were plentiful and shallow at the same time. "Write more
+assertions" would not have fixed one of them.
+
+Recovery when you find a green-on-first-run test is not to delete it: add one case that **fails
+right now**, against the implementation as it stands. If you cannot write one, you are not yet
+testing the spec.
+
+## How much test is enough — the completeness checklist
+
+A component is covered when, for its spec, the test class has:
+
+| | What | Why it is not optional |
+|---|---|---|
+| 1 | **The happy path, asserting on values** — not merely on `$$$ISOK` | A green `%Status` says the code ran, not that it was right |
+| 2 | **One rejection case per validation rule in the spec** | Each rule is a claim; an untested rule is a guess |
+| 3 | **Boundary values** — empty, maximum length, zero, first and last valid item | `MAXLEN` truncation and off-by-one live exactly here, and both fail *silently* |
+| 4 | **The malformed inputs the spec says to reject**, asserting the *rejection* | "Rejected cleanly" and "blew up" are different outcomes; only one is correct |
+| 5 | **One case per branch you wrote** — each `if`, each `switch` case, each `<when>` of a rule | An unexercised branch is untested code under a passing suite |
+
+The fixtures usually *are* the checklist in disguise. A CSV censo flow whose spec says *dates are
+`DD/MM/YYYY`*, *allergies are `|`-separated and empty means SQL NULL*, *a quoted comma is one
+field*, *`ñ` and accents are preserved* has **four** edge cases named in the spec itself — and a
+date like `32/13/1990` sitting in the sample data is not a nuisance, it is test case 4 handed to
+you.
+
+Anti-pattern worth naming: a `Test*` method whose only assertion is `$$$AssertStatusOK(sc)`. That
+asserts the component did not error. It does not assert it did the right thing, and it passes
+against an implementation that silently drops every field.
+
 ## What's testable in IRIS Interop — decision table
 
 | Component | Test approach |


### PR DESCRIPTION
A student reported that the tests produced for each component were too shallow to really exercise it, and that some components were finished with **no test run at all**. Both are real, they have **different causes**, and the obvious fix for the first one is wrong.

Measured over the finished workshop: 18 students, 567 component classes.

## 1. The guard never fired — not once, for anyone

Its component detector was `\.bo\.|\.bp\.|dtl|rule`, applied to a **file path**. The class is `Pkg.BO.Name` but the file is `src/Pkg/BO/Name.cls` — the `interop` skill mandates the **Atelier nested layout**, so the path carries directory separators, not dots.

| path | hook |
|---|---|
| `src\Ejercicio3\BO\MenusSQL.cls` — the layout the skill mandates | **silent** |
| `Ejercicio3.BO.MenusSQL.cls` — the flat-dotted form the skill calls the error | fires |

It also lacked `DT` and `RUL` entirely, so transforms and routing rules were invisible even in flat-dotted form (`dtl` does not match `dt.`; `rule` does not match `rul.`).

**Fixed**: the type segment may be delimited by a dot **or** a path separator, and `BS`/`DT`/`DTS`/`RUL` are included. The hook now also watches `iris_doc(mode=put)`, since classes reach IRIS either as a file or straight through the MCP.

## 2. The tests were written after the code

**67 of 103 test classes (65%) were GREEN on their first ever run.** In `spec → test → RED → implement → green` the first run is red. Green immediately means the test was written against code that already existed — so it encodes current behaviour instead of the specification, and a bug is faithfully recorded as the expected result.

The tempting diagnosis — *"not enough assertions"* — **is wrong, and the data says so**:

| | |
|---|---|
| `Test*` methods per class | 5.3 |
| asserts per method | 2.8 |
| classes with zero asserts | 2 of 220 |

The tests were plentiful and shallow *at the same time*. Prescribing more assertions would not have fixed one of them.

**New hook** `tdd_first_green.py` (PostToolUse on `iris_test`): flags a test class whose **first** run is green and asks for one case that fails against the implementation as it stands. Keeps a per-project ledger so "first" means first in the project, not in the session, and stays silent on red — red is the desired outcome.

## 3. The skill never said when you are done

`tdd` documented the cycle but not its exit condition, so *"a test exists"* became the bar. Added:

- **Step 3 is load-bearing** — a test that never went red proves nothing, with the cohort numbers.
- **A five-point completeness checklist**: happy path asserting on *values* not just `$$$ISOK`; one rejection case per validation rule in the spec; boundary values; the malformed inputs the spec says to reject, asserting the *rejection*; one case per branch written.
- The observation that **exercise fixtures usually are that checklist in disguise** — a `32/13/1990` sitting in the sample data is not a nuisance, it is a test case handed to you.
- The anti-pattern of a `Test*` method whose only assertion is `$$$AssertStatusOK(sc)`: it asserts the component did not error, and passes against an implementation that silently drops every field.

## Verification

Both hooks driven via stdin — **12 cases, 0 failures**:

- Atelier `BO`/`DT`/`RUL` paths and `iris_doc put` → all fire
- `iris_doc get`, the test class itself, a non-`.cls` file, and a project that already has a `*Test*.cls` → all silent
- first-green fires **once and only once**; red never fires

## Not changed

The guard still **advises**; it does not block. Making it deny is a policy decision about student friction that has not been taken yet — the mechanism is one `deny()` away when you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)