### PR TITLE
docs(skills): tell the generator skills to export what the generator wrote

### DIFF
--- a/skills/bpl/SKILL.md
+++ b/skills/bpl/SKILL.md
@@ -267,6 +267,13 @@ A class that compiled fine on an older Caché/Ensemble may report `Missing BPL D
 
 **Fix**: paste the original BPL XML back into the `XData BPL` block and recompile. **Prevention**: source-control the BPL class as-text on disk, not just as a portal-edited class — see `production-lifecycle` for the disk-as-source-of-truth principle.
 
+**The BPL editor and the rule editor both write straight into the namespace.** The PreToolUse
+source-of-truth gate cannot see them — it watches `iris_doc(mode=put)`, and a Portal edit
+bypasses it. After any editing session in the Portal, `iris_doc(mode=get)` the BPL class and the
+`Ens.Rule.Definition` class and write them to `src/`. This is what makes the regression above
+recoverable: with the XData on disk, restoring a stripped `XData BPL` is a copy-paste; without
+it, the process definition is gone.
+
 ## Canonical routing / BPL shapes
 
 Four shapes cover most orchestration needs. Reach for the closest match before authoring from scratch:

--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -141,6 +141,13 @@ Alternatives that **fail**:
 
 Worked example: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch03_cda/cda-from-xsd-persistence-pattern.cls`.
 
+**Export what the wizard generated.** A CDA XSD produces dozens of classes, all of them written
+straight into the namespace — the source-of-truth gate never sees them, because the wizard does
+not go through `iris_doc(mode=put)`. `iris_doc(mode=get)` the generated package and write it to
+`src/` before doing anything else; the three settings above are edits *on top of* generated code,
+and losing them means re-deriving them from a 60-second serialisation failure. Same rule for
+SOAP-wizard output (`soap-bo`) and for the RecordMap generator (`business-services`).
+
 **Stylesheet security note**: the standard HL7 CDA stylesheet (`cda.xsl`) had multiple security holes before April 2014 — XSS via `nonXMLBody` rendered inside an `<iframe>`, illegal table attributes (`onmouseover`), image URIs to hostile sites. Use only the patched version from the HL7 Structured Documents Working Group.
 
 ## Comanda / Resposta inheritance for one-of-N payload subtypes

--- a/skills/soap-bo/SKILL.md
+++ b/skills/soap-bo/SKILL.md
@@ -24,6 +24,30 @@ Output:
 - A BO class extending `Ens.BusinessOperation` with one method per WSDL operation, plus `MessageMap` dispatch.
 - One request class and one response class per operation, plus shared type classes.
 
+### Export the generated classes to `src/` — the wizard writes only to the namespace
+
+**The wizard is the largest single producer of namespace-only classes in this toolset.** One
+WSDL yields the proxy, the BO, `WSC.*`, `SOAPENC.*`, and a request/response pair per operation
+— none of which pass through disk. The PreToolUse source-of-truth gate cannot help here: it
+watches `iris_doc(mode=put)`, and the wizard bypasses that entirely.
+
+So the rule for generated code is the mirror image of the rule for hand-written code:
+
+```
+hand-written:  Write src/… .cls   →  iris_doc(mode=put)      (gate enforces this order)
+generated:     run the wizard     →  iris_doc(mode=get)  →  Write src/… .cls
+```
+
+Immediately after the wizard runs, `iris_doc(mode=get)` **every** class it created and write it
+to `src/` in the Atelier nested layout. Do it before you start patching them — the patches
+below (`OUTPUTTYPEATTRIBUTE`, dropped `[ Required ]`, widened `MAXLEN`, the
+`wsp:PolicyReference` removal) are exactly the edits you cannot afford to lose, and they are
+invisible to anyone reading the WSDL.
+
+Measured on a workshop VM: 28 classes on disk, 29 in IRIS, only 22 in common — with drift in
+**both** directions, including generated SOAP classes that existed on disk but no longer in the
+namespace. See `production-lifecycle` for the `DriftReport` check.
+
 ## Review the generated payloads — the `MAXLEN=50` truncation trap
 
 When the WSDL declares a string type **without a length facet**, the wizard-generated property comes out as a **bounded `%String` with the default `MAXLEN=50`** — longer values are then **silently truncated** on save (no error). Always audit the generated payload classes after running the wizard and **widen** affected string properties to `%String(MAXLEN="")` (unbounded, ~3.6 MB ceiling) or `%Stream.GlobalCharacter` for large content. Same trap, longer treatment in `messages` (`%String` length section).


### PR DESCRIPTION
The source-of-truth gate from #17 watches `iris_doc(mode=put)`, so it protects **hand-written** classes. It is blind to the wizards: the SOAP wizard, the XML Schema wizard, the BPL editor and the rule editor all write straight into the namespace **without going through the MCP at all**.

Those are precisely the classes #17 has to exempt — which means the only thing standing between them and permanent loss is the skill telling you to export them.

`business-services` (RecordMap) and `production-lifecycle` already said it. **The skills that generate the most classes did not.**

## The rule, stated as a mirror image

```
hand-written:  Write src/… .cls   →  iris_doc(mode=put)      ← the gate enforces this order
generated:     run the wizard     →  iris_doc(mode=get)  →  Write src/… .cls
```

## What changed

**`soap-bo`** — the largest single producer of namespace-only classes in the toolset. One WSDL yields the proxy, the BO, `WSC.*`, `SOAPENC.*`, and a request/response pair per operation, none of which pass through disk. Added the rule *and the reason to do it before patching*: `OUTPUTTYPEATTRIBUTE`, dropped `[ Required ]`, widened `MAXLEN`, the `wsp:PolicyReference` removal — all are edits **on top of** generated code, invisible to anyone reading the WSDL, and unrecoverable if lost.

**`messages`** — a CDA XSD produces dozens of classes, and the three persistence settings that make them work are edits on top of generated code. Losing them means re-deriving them from a 60-second serialisation failure.

**`bpl`** — the BPL editor and the rule editor bypass the gate the same way. Named the concrete step and tied it to the `Missing BPL Data` regression documented two lines above: with the XData on disk, restoring a stripped `XData BPL` is a copy-paste; without it, the process definition is gone.

**`hl7-schemas`** needed nothing — it already exports to SCM after a Portal edit, and its MCP path authors the XML on disk first.

## Coverage after this PR

| skill | says how to export |
|---|---|
| `soap-bo` | ✅ new |
| `messages` | ✅ new |
| `bpl` | ✅ new |
| `business-services` | ✅ already |
| `hl7-schemas` | ✅ already |
| `production-lifecycle` | ✅ already (the principle + `DriftReport`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)