### PR TITLE
feat(conformance-review): CR-12 — a class in the namespace but not in src/

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ call (e.g. `check_config`) runs without a prompt.
 | `message-search-debug` | Message search, Visual Trace, the Event Log. |
 | `tdd` | TDD-first workflow (companion skill — load it alongside the others). |
 | `unit-tests` | `%UnitTest` framework reference. |
-| `conformance-review` | Post-build best-practice review (criteria CR-1…CR-11) — run it once a build is TDD-green. |
+| `conformance-review` | Post-build best-practice review (criteria CR-1…CR-12) — run it once a build is TDD-green. |
 | `report-issue` | Optionally propose a **deduped, user-confirmed** GitHub issue for a confirmed compliance violation or a reproducible MCP/skill defect (never auto-files; batches findings). |
 
 ### Agents (`agents/`)
@@ -212,7 +212,7 @@ Claude delegate based on the task description:
 | `interop-builder` | Build/modify any interop component end-to-end with TDD — loads the right skills, writes the test first, implements via the MCP, returns only when it compiles and the test is green. |
 | `deploy-smoke-test` | Start a production, feed a sample input, and verify the message actually flowed (Event Log + Message Header + downstream target). |
 | `introspect-dont-guess` | Resolve real class/table/column/config names from the live IRIS catalog instead of guessing (prevents nonexistent-table errors). |
-| `conformance-reviewer` | After a build is TDD-green, review it against the best-practice criteria (CR-1…CR-11) — re-verifies tests via the real `iris_test` (not a self-graded `[SqlProc]`), reports findings + a scoped remediation plan, applies only unambiguous fixes after you confirm. |
+| `conformance-reviewer` | After a build is TDD-green, review it against the best-practice criteria (CR-1…CR-12) — re-verifies tests via the real `iris_test` (not a self-graded `[SqlProc]`), reports findings + a scoped remediation plan, applies only unambiguous fixes after you confirm. |
 
 The agents are **MCP-server-agnostic** (no server name pinned in their tools), so they work with either
 the `iris-agentic-dev` or `iris-interop-dev` MCP.

--- a/agents/conformance-reviewer.md
+++ b/agents/conformance-reviewer.md
@@ -12,7 +12,7 @@ approves a remediation item.
 
 ## The criteria are not in your memory — load them
 
-`Skill(iris-interop-skills:conformance-review)` is the **single source of truth** (criteria CR-1…CR-11).
+`Skill(iris-interop-skills:conformance-review)` is the **single source of truth** (criteria CR-1…CR-12).
 Load it first, then load the component skills for whatever is in the build so you judge against their
 guidance, not recollection: `iris-interop-skills:interop` (naming/router) plus `:bpl`,
 `:business-services`, `:transformations`, `:alerting`, `:hl7-schemas`, `:messages`, `:tdd` as applicable.
@@ -26,9 +26,21 @@ guidance, not recollection: `iris-interop-skills:interop` (naming/router) plus `
    `%UnitTest.TestProduction` class and record the genuine result. A build that "passed" only through a
    self-authored `[SqlProc]` runner read with `iris_query` is **unverified** — flag CR-7 as P0. If
    `iris_test` errors, that is a finding, not a pass.
-3. **Check every criterion** CR-1…CR-11 against the actual code. For each, cite `file:line` and state the
+3. **Check every criterion** CR-1…CR-12 against the actual code. For each, cite `file:line` and state the
    best-practice it meets or breaks. Be specific; a pass-through BP, a `$Piece` file loop, a `<code>`-only
    DTL, a `MSH:9.x` rule, an unfed alert circuit, a hardcoded path — name the exact line.
+3b. **Diff the namespace against the source tree** (CR-12). Every other criterion is answered by reading
+   code; this one needs both sides, and it is the only finding that can make the work *unrecoverable*:
+
+   ```
+   iris_symbols(query="<Pkg>.*", namespace="<NS>", limit=500)   # default limit is 20 — raise it
+   Glob("**/src/**/*.cls")
+   ```
+
+   Normalise both to class names (`src/Pkg/BO/Name.cls` → `Pkg.BO.Name`) and report **both** directions:
+   classes only in IRIS (outside git, gone with the instance) and classes only on disk (never compiled,
+   or deleted from the namespace — so the running production is not what the tree claims). Wizard and
+   generator output is the usual source of the first kind, since it never passes through `iris_doc`.
 4. **Separate verdicts from judgment calls.** Some "violations" are defensible (the criteria table marks
    P2/P3 nuance). Do not inflate. Report what is genuinely off.
 

--- a/skills/conformance-review/SKILL.md
+++ b/skills/conformance-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conformance-review
-description: Review an already-built IRIS Interoperability production against the iris-interop best-practice criteria AFTER implementation + TDD, and report what does not conform with the canonical fix. Use after building/modifying components, before declaring done, or whenever the user asks "is this implemented correctly / per best practices / conforme". This skill is the single source of truth for the conformance criteria (CR-1…CR-11); the `conformance-reviewer` agent and the `conformance-prescan` hook both check against it. Triggers EN: review, conformance, best practices, is this correct, code review, ready to ship. Triggers ES: revisar, conformidad, buenas prácticas, está bien implementado, cumple, revisión.
+description: Review an already-built IRIS Interoperability production against the iris-interop best-practice criteria AFTER implementation + TDD, and report what does not conform with the canonical fix. Use after building/modifying components, before declaring done, or whenever the user asks "is this implemented correctly / per best practices / conforme". This skill is the single source of truth for the conformance criteria (CR-1…CR-12); the `conformance-reviewer` agent and the `conformance-prescan` hook both check against it. Triggers EN: review, conformance, best practices, is this correct, code review, ready to ship. Triggers ES: revisar, conformidad, buenas prácticas, está bien implementado, cumple, revisión.
 ---
 
 # IRIS Interoperability — Conformance Review
@@ -30,9 +30,19 @@ re-plan from scratch and it never rewrites silently.
 2. **Load the relevant skills** so you judge against their guidance, not memory: `iris-interop-skills:interop`
    (router/naming), plus the component skills in play (`:bpl`, `:business-services`, `:transformations`,
    `:alerting`, `:hl7-schemas`, `:messages`, `:tdd`).
-3. **Check every criterion below** (CR-1…CR-11) against the actual code. Cite `file:line` and the exact
+3. **Check every criterion below** (CR-1…CR-12) against the actual code. Cite `file:line` and the exact
    best-practice it meets or breaks.
 4. **Re-verify tests for real** (CR-7): run `iris_test` on the test class; record the genuine result.
+4b. **Compare the namespace against the source tree** (CR-12). This is the one check that cannot be
+   done by reading code — it needs both sides:
+
+   ```
+   iris_symbols(query="<Pkg>.*", namespace="<NS>", limit=500)   ← default limit is 20; raise it
+   Glob("**/src/**/*.cls")                                       ← the tree
+   ```
+
+   Normalise both to class names (`src/Pkg/BO/Name.cls` → `Pkg.BO.Name`) and diff **in both
+   directions**. Report anything present in one and not the other.
 5. **Emit the report** (severity-tagged) → **a scoped remediation plan** → offer to **apply the safe
    fixes** (P0/P1 with an unambiguous canonical fix) only after the user confirms. Leave defensible
    choices as notes, not edits.
@@ -44,7 +54,7 @@ re-plan from scratch and it never rewrites silently.
 - **P2** — idiomatic gap that works but loses tooling/robustness (declarative vs procedural; missing alerts).
 - **P3** — cosmetic / naming / hardcoded paths.
 
-## Criteria (CR-1 … CR-11)
+## Criteria (CR-1 … CR-12)
 
 Items marked **⚙ pre-scannable** are also detected mechanically by the `conformance-prescan` hook from a
 single file's text; the rest need the agent's cross-file/semantic judgment.
@@ -62,6 +72,7 @@ single file's text; the rest need the agent's cross-file/semantic judgment.
 | **CR-9** | P3 | Naming: classes not `<Pkg>.<Tipo>.<Nombre>` (`.BS`/`.BP`/`.BO`/`.DT`/`.RUL`/`.MSG`), or production **Item Name** not `<Tipo>.<Nombre>`; Category ≠ package root. | Apply the interop naming convention; Category = package root; fixed `Ens.Alerts`. | `interop` |
 | **CR-10** ⚙ | P3 | A `.cls` with a **hardcoded absolute path** (`C:\…`, `/tmp/…`) instead of resolving relative to the install/source dir. | Parametrize via a Setting, or resolve with `##class(%Library.File).TempFilename`/`InstallDirectory`. | `production-lifecycle` |
 | **CR-11** ⚙ | P2 | An **object property of a message resolved to a `%Persistent` class with no delete cascade** — no `Trigger [ Event = DELETE ]` and no `%OnDelete` on the referencing message, no `OnDelete = Cascade` on the link. `Ens.Util.Tasks.Purge` then deletes the message and orphans the child rows, silently, forever. | Make it `%SerialObject` in `<Pkg>.DAT.<Name>` if it's a value object owned by the message (the default); if it must be `%Persistent` (shared / queried on its own / recursive / large), add the delete cascade to the **referencing** message class. | `messages` |
+| **CR-12** | **P1** | **A class exists in the IRIS namespace but not in `src/`** (or the reverse). The namespace is not version-controlled, not reviewable, and does not survive the instance — so work that lives only there is already lost, it just hasn't been noticed yet. Check both directions: a class only on disk was never compiled, or was deleted from the namespace, and the running production does not contain what the tree says it does. | `iris_doc(mode=get)` the namespace-only classes and write them to `src/` in the Atelier nested layout; compile or delete the disk-only ones so the two agree. Then fix the cause: hand-written classes go **`Write` → `iris_doc(mode=put)`** (a PreToolUse gate enforces it), wizard/generator output goes **generate → `iris_doc(mode=get)` → `Write`** (`soap-bo`, `messages`, `business-services`). | `production-lifecycle`, `soap-bo` |
 
 ## Output template
 

--- a/skills/interop/SKILL.md
+++ b/skills/interop/SKILL.md
@@ -124,7 +124,7 @@ System Default Settings are the **only** layer that does NOT migrate via a produ
 | **Securing endpoints** — SAML 2.0 / 1.1, OAuth 2.0 server + LDAP, SSL/TLS chain, internal account hygiene | `iris-interop-skills:security` |
 | **Alert circuit** — `Ens.Alert` router, dedup function set, ProductionMonitorService, per-BO alert settings | `iris-interop-skills:alerting` |
 | **About to build *anything* (DTL, rule, BO method, BPL) — TDD workflow** | **`iris-interop-skills:tdd`** (entry point; non-negotiable) |
-| **Built it and TDD-green — is it idiomatic / per best practices?** (run before declaring done) | **`iris-interop-skills:conformance-review`** (criteria CR-1…CR-11; the `conformance-reviewer` agent runs it) |
+| **Built it and TDD-green — is it idiomatic / per best practices?** (run before declaring done) | **`iris-interop-skills:conformance-review`** (criteria CR-1…CR-12; the `conformance-reviewer` agent runs it) |
 | %UnitTest framework toolbox (storage, runner flags, ^UnitTest.Result) | `iris-interop-skills:unit-tests` (lower-level reference; the TDD skill calls into it) |
 | Anything DICOM (C-STORE, C-FIND, C-MOVE, MWL, STOW-RS, modalities, PACS) | `iris-interop-skills:dicom` (architecture + wiring patterns; defers byte-level work to docs + vendored sample at `${CLAUDE_PLUGIN_ROOT}/BestPractices/external/workshop-iris-dicom-interop/`) |
 
@@ -188,7 +188,7 @@ For a typical end-to-end interface, work in this order — it minimises rework b
 9. **Production wiring + settings** (`production-lifecycle`) — add `TestingEnabled="true"` for dev productions; choose deployment tool early
 10. **Security** (`security`) — only after components exist; SAML/OAuth/SSL added where the endpoints actually call out
 11. **Test, search, debug** (`message-search-debug`) — Visual Trace + Event Log for verifying end-to-end runs; purge task added
-12. **Conformance review** (`conformance-review`) — once built and TDD-green, review against the best-practice criteria (CR-1…CR-11) before declaring done; spawn the `conformance-reviewer` agent. It re-verifies tests via the real `iris_test` tool (never a self-graded `[SqlProc]`), reports findings with the canonical fix, and proposes a scoped remediation plan.
+12. **Conformance review** (`conformance-review`) — once built and TDD-green, review against the best-practice criteria (CR-1…CR-12) before declaring done; spawn the `conformance-reviewer` agent. It re-verifies tests via the real `iris_test` tool (never a self-graded `[SqlProc]`), reports findings with the canonical fix, and proposes a scoped remediation plan.
 
 For FHIR-specific work, replace steps 4–7 with the `fhir` decision tree (Façade vs Repository, OAuth2 PKCE setup, FHIR R4 Bundle shape).
 

--- a/skills/report-issue/SKILL.md
+++ b/skills/report-issue/SKILL.md
@@ -17,7 +17,7 @@ This skill turns a confirmed problem into a **draft** issue and proposes it to t
 
 ## What's reportable
 
-- **Compliance / best-practice** (from `conformance-review`): a *confirmed* P0/P1 finding (CR-1…CR-11).
+- **Compliance / best-practice** (from `conformance-review`): a *confirmed* P0/P1 finding (CR-1…CR-12).
   Not P2/P3 nits, not unconfirmed/defensible calls.
 - **MCP / skill defect**: a *reproducible* tool malfunction in the deployed version — a tool that returns a
   wrong/empty result, an error_code that doesn't match reality, a crash, a skill that misroutes. Must have a


### PR DESCRIPTION
Your suggestion, and it closes the gap the last two PRs left open.

- #17 stops Claude writing a class **straight to IRIS**.
- #18 tells the generator skills to **export what the wizards produce**.
- Neither detects the drift that **already exists**, and neither can see a Portal or wizard edit — those bypass the MCP entirely, so no hook will ever intercept them.

The review is the right place for that check: it runs after the build, before the work is called done, and the reviewer agent can query the namespace — something the single-file prescan cannot.

## CR-12, P1, not pre-scannable

It is the one criterion that **cannot be answered by reading code**, because it needs both sides:

```
iris_symbols(query="<Pkg>.*", namespace="<NS>", limit=500)   # default limit is 20 — raise it
Glob("**/src/**/*.cls")
```

Normalise to class names (`src/Pkg/BO/Name.cls` → `Pkg.BO.Name`) and diff **both directions**:

| direction | what it means |
|---|---|
| only in IRIS | outside git, outside review, gone with the instance |
| only on disk | never compiled, or deleted from the namespace — the running production is **not** what the tree claims |

The audit that prompted this had **both**, on the same VM: 28 on disk, 29 in IRIS, 22 in common.

## Why P1 and not P2

P2 is *"works but loses tooling/robustness"*. This is not that. The consequence is that **the work is already lost and nobody has noticed yet** — a whole HL7 flow, in the case that surfaced it. The canonical fix therefore names the cause as well as the symptom:

```
hand-written:  Write src/… .cls   →  iris_doc(mode=put)          ← gate enforces (#17)
generated:     run the wizard     →  iris_doc(mode=get) → Write  ← skills say so (#18)
```

## Also

Wired into the review workflow as **step 4b** and into the `conformance-reviewer` agent as **step 3b**, so it runs rather than merely being listed. Range updated `CR-1…CR-11` → `CR-1…CR-12` across the skill description, the agent, README, `interop` and `report-issue` (10 occurrences).

Verified: 12 criteria present and in order; CR-12 correctly **not** marked ⚙; the prescan hook does not attempt it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)