### PR TITLE
infra: daily traffic snapshot — persist clone/view counts past GitHub's 14-day window

### DIFF
--- a/.github/workflows/traffic-snapshot.yml
+++ b/.github/workflows/traffic-snapshot.yml
@@ -1,0 +1,38 @@
+# traffic-snapshot: persist GitHub clone/view stats past the API's 14-day window.
+# Data files live on the `traffic-data` branch (kept out of main's history).
+# Requires the TRAFFIC_TOKEN secret — see scripts/traffic_snapshot.py.
+
+name: traffic-snapshot
+
+on:
+  schedule:
+    - cron: '17 3 * * *'  # daily; 14-day API retention leaves ~13 days of retry headroom
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          ref: traffic-data
+          path: traffic-data
+
+      - name: Snapshot traffic
+        env:
+          TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+        run: python3 scripts/traffic_snapshot.py traffic-data | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit history
+        run: |
+          cd traffic-data
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add clones.json views.json
+          git commit -m "traffic: snapshot $(date -u +%F)" || exit 0
+          git push origin traffic-data

--- a/scripts/traffic_snapshot.py
+++ b/scripts/traffic_snapshot.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Snapshot GitHub traffic (clones/views) into a permanent per-day history.
+
+GitHub's traffic API only retains a rolling 14-day window and there is no
+all-time counter. This script — run daily by
+.github/workflows/traffic-snapshot.yml — fetches the current window and
+merges it into per-day history files (clones.json / views.json, kept on the
+`traffic-data` branch), so the cumulative numbers survive forever.
+
+Merge rule: upsert by date, keeping max(count) per day — the API revises the
+current (partial) day upward, so max() is idempotent across overlapping runs.
+
+Requires TRAFFIC_TOKEN: a PAT able to read repo traffic (classic: `repo`
+scope; fine-grained: Administration read-only on this repo). The default
+Actions GITHUB_TOKEN cannot read the traffic endpoints.
+
+Usage: traffic_snapshot.py <data-dir>
+"""
+import json
+import os
+import sys
+import urllib.request
+from datetime import datetime, timezone
+
+REPO = os.environ.get("GITHUB_REPOSITORY", "intersystems-ib/iris-interop-skills")
+TOKEN = os.environ.get("TRAFFIC_TOKEN")
+
+
+def fetch(kind):
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{REPO}/traffic/{kind}",
+        headers={
+            "Authorization": f"Bearer {TOKEN}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req) as r:
+        return json.load(r)
+
+
+def merge(path, rows):
+    try:
+        with open(path) as f:
+            hist = json.load(f)
+    except FileNotFoundError:
+        hist = {"days": {}}
+    days = hist["days"]
+    for row in rows:
+        day = row["timestamp"][:10]
+        prev = days.get(day, {"count": 0, "uniques": 0})
+        days[day] = {
+            "count": max(prev["count"], row["count"]),
+            "uniques": max(prev["uniques"], row["uniques"]),
+        }
+    hist["days"] = dict(sorted(days.items()))
+    hist["total_count"] = sum(d["count"] for d in days.values())
+    # Uniques dedupe only within one day; summing them is an upper bound.
+    hist["daily_uniques_sum"] = sum(d["uniques"] for d in days.values())
+    hist["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with open(path, "w") as f:
+        json.dump(hist, f, indent=2)
+        f.write("\n")
+    return hist
+
+
+def main():
+    if not TOKEN:
+        sys.exit(
+            "TRAFFIC_TOKEN is not set. Create a PAT that can read repo traffic "
+            "(classic: repo scope / fine-grained: Administration read) and add "
+            "it as an Actions secret named TRAFFIC_TOKEN."
+        )
+    data_dir = sys.argv[1] if len(sys.argv) > 1 else "traffic-data"
+    for kind in ("clones", "views"):
+        data = fetch(kind)
+        hist = merge(os.path.join(data_dir, f"{kind}.json"), data.get(kind) or [])
+        print(
+            f"{kind}: all-time {hist['total_count']} "
+            f"(≤{hist['daily_uniques_sum']} uniques, {len(hist['days'])} days tracked)"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
GitHub retains repo traffic (clones ≈ plugin installs, views) for only a rolling 14-day window, and this repo has no release assets — so there was no durable install count. This adds one:

- **`scripts/traffic_snapshot.py`** — stdlib-only; fetches `/traffic/clones` + `/traffic/views` and merges them into per-day history files. Upsert by date keeping `max(count)` per day, so overlapping windows and partial-day revisions are idempotent. Emits all-time totals (uniques reported as an upper bound — GitHub dedupes per day only).
- **`.github/workflows/traffic-snapshot.yml`** — daily cron (03:17 UTC) + `workflow_dispatch`. Daily runs against a 14-day window leave ~13 days of retry headroom if runs fail.
- **Data lives on the `traffic-data` branch** (already pushed, seeded with the 2026-08-10..24 window before it expires): `clones.json`, `views.json`, and a README documenting the format. Keeps daily bot commits out of `main`'s history; the daily commit also keeps the scheduled workflow from being auto-disabled for inactivity.

**Required setup (one manual step):** the traffic endpoints are NOT readable by the built-in `GITHUB_TOKEN` — they need a PAT (classic: `repo` scope, or fine-grained: this repo, Administration read-only) stored as an Actions secret named **`TRAFFIC_TOKEN`**. Until it is set, runs fail with a message saying exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)