### PR TITLE
fix(traffic-snapshot): pipefail so a script failure isn't masked by tee

### DIFF
--- a/.github/workflows/traffic-snapshot.yml
+++ b/.github/workflows/traffic-snapshot.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Snapshot traffic
         env:
           TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN }}
+        # explicit `shell: bash` gets -o pipefail, so a script failure isn't masked by tee
+        shell: bash
         run: python3 scripts/traffic_snapshot.py traffic-data | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Commit history


### PR DESCRIPTION
First real run of the workflow exposed a silent-failure hole: the snapshot step pipes the script through `tee` into the step summary, and GitHub's default `run` shell is `bash -e` **without** `pipefail` — so the step's status was tee's, and the script aborting with "TRAFFIC_TOKEN is not set" still went green, leaving the commit step to no-op on a clean tree. Declaring `shell: bash` explicitly makes GitHub run it with `--noprofile --norc -eo pipefail`, so the script's exit code fails the step as designed.

(The triggering incident: `gh secret set` without `--body` read an empty stdin and stored an empty secret — the workflow should have failed loudly on that, and now does.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)