### PR TITLE
fix(hooks): tdd_enforcement matches Tipo segments not path substrings; recognises Tests/-package tests

### DIFF
--- a/hooks/tdd_enforcement.py
+++ b/hooks/tdd_enforcement.py
@@ -5,23 +5,32 @@ If an interop implementation class (BS/BP/BO/DT/DTS/RUL, DTL, Rule) is written W
 test for it, remind the model to write the test first (spec -> test -> red -> implement ->
 green; tests extend %UnitTest.TestProduction). Advisory only; never blocks.
 
-Two things this has to get right, both learned from a workshop cohort where it fired zero
-times across 18 students and 567 component classes:
+Three things this has to get right, learned across two evaluation rounds (a cohort where it
+fired zero times, then a corpus where every fire was a false positive):
 
-  1. The component detector must accept BOTH shapes of name. The class is `Pkg.BO.Name`
-     but the FILE is `src/Pkg/BO/Name.cls` — the `interop` skill mandates the Atelier
-     nested layout, so the path carries directory separators, not dots. A detector written
-     as `\\.bo\\.` matches only the flat-dotted form that same skill tells you not to use.
+  1. The component detector must accept BOTH shapes of name — the class is `Pkg.BO.Name`
+     but the FILE is `src/Pkg/BO/Name.cls` (Atelier nested layout) — and the type must be a
+     DELIMITED SEGMENT, never a bare substring. Matching `dtl`/`rule` anywhere in the path
+     fired on every class under a directory like `hl7-dtl-mapping/` or `DTL-BUILD-01/`
+     while missing real `.DT.` classes entirely.
   2. It must cover the tools actually used. Classes reach IRIS either as a file
      (Write/Edit) or straight through `iris_doc(mode=put)`; watching only the first misses
      everything written directly to the namespace.
+  3. "A test exists" must recognise the plugin's OWN documented convention. The tdd skill
+     prescribes `MyApp.Tests.DT.Censo2Menus` -> `Tests/DT/Censo2Menus.cls`: the test lives
+     in a `Tests` package and its basename carries no "Test" substring. A basename-only
+     check nags the test file itself and re-fires forever on already-tested classes.
 """
 import sys, json, os, re, glob
 
-# Type segment delimited by a dot OR a path separator: matches `Pkg.BO.Name` and
-# `src/Pkg/BO/Name.cls` alike. DTS/DT/RUL/BS included — the old pattern had neither
-# `dt` nor `rul`, so transforms and rules were invisible even in flat-dotted form.
-COMPONENT = re.compile(r"[./\\](?:BS|BP|BO|DT|DTS|RUL)[./\\]|DTL|Rule", re.I)
+# Type segment delimited by a dot OR a path separator on BOTH sides: matches `Pkg.BO.Name`
+# and `src/Pkg/BO/Name.cls`, never a substring of a directory name. `DTL`/`Rule` are kept
+# as segment-anchored aliases for projects that don't use the Tipo abbreviations.
+COMPONENT = re.compile(r"[./\\](?:BS|BP|BO|DT|DTS|RUL|DTL|Rule)[./\\]", re.I)
+
+# The write IS a test: basename contains "test", or the class/file sits in a Test/Tests
+# package or directory (the convention `tdd` documents).
+TESTS_SEG = re.compile(r"[./\\]Tests?[./\\]", re.I)
 
 
 def component_name(ti):
@@ -33,6 +42,18 @@ def component_name(ti):
     return path if str(path).lower().endswith(".cls") else ""
 
 
+def has_tests(root):
+    """Any test under root: *Test*.cls anywhere, or any .cls inside a Test/Tests dir."""
+    if not root:
+        return False
+    if glob.glob(os.path.join(root, "**", "*Test*.cls"), recursive=True):
+        return True
+    for d in ("Tests", "Test"):
+        if glob.glob(os.path.join(root, "**", d, "**", "*.cls"), recursive=True):
+            return True
+    return False
+
+
 def main():
     try:
         data = json.load(sys.stdin)
@@ -40,31 +61,39 @@ def main():
         return
     ti = data.get("tool_input", {}) or {}
     target = component_name(ti)
-    if not target or not COMPONENT.search(target):
+    if not target:
         return
-    base = os.path.basename(str(target).replace("\\", "/"))
-    if "test" in base.lower():  # the test itself — fine
+    norm = str(target).replace("\\", "/")
+    if not COMPONENT.search(norm):
+        return
+    base = os.path.basename(norm)
+    if "test" in base.lower() or TESTS_SEG.search(norm):  # the test itself — fine
         return
 
     # A test anywhere in the project counts. Deliberately loose: the goal is to nudge when
-    # there is NO test at all, not to police naming.
+    # there is NO test at all, not to police naming. The parent dir is included because the
+    # documented layout puts Tests/ beside the Tipo dirs (src/Pkg/DT/ vs src/Pkg/Tests/).
     roots = []
-    d = os.path.dirname(str(target).replace("\\", "/"))
+    d = os.path.dirname(norm)
     if d and os.path.isdir(d):
         roots.append(d)
+        parent = os.path.dirname(d)
+        if parent and os.path.isdir(parent):
+            roots.append(parent)
     proj = os.environ.get("CLAUDE_PROJECT_DIR")
-    if proj:
+    if proj and proj not in roots:
         roots.append(proj)
     for r in roots:
-        if r and glob.glob(os.path.join(r, "**", "*Test*.cls"), recursive=True):
+        if has_tests(r):
             return
 
     msg = (
-        "TDD: you just wrote the interop component " + base + " and no *Test*.cls exists "
-        "for it. Per iris-interop-skills:tdd the order is spec -> test -> RED -> implement "
-        "-> green: write the test first and SEE IT FAIL, so it tests the spec rather than "
-        "the code you already wrote. Test classes extend %UnitTest.TestProduction. "
-        "A component is not done until iris_test returns green on a test that was red before."
+        "TDD: you just wrote the interop component " + base + " and no test class exists "
+        "for it (neither *Test*.cls nor a Tests/ package). Per iris-interop-skills:tdd the "
+        "order is spec -> test -> RED -> implement -> green: write the test first and SEE "
+        "IT FAIL, so it tests the spec rather than the code you already wrote. Test classes "
+        "extend %UnitTest.TestProduction. A component is not done until iris_test returns "
+        "green on a test that was red before."
     )
     print(json.dumps({"hookSpecificOutput": {
         "hookEventName": "PostToolUse", "additionalContext": msg}}))


### PR DESCRIPTION
Closes #27

Both reported bugs, fixed against the current (already partially-rewritten) hook:

**Bug A — trigger matched raw-path substrings.** The Tipo core (`BS|BP|BO|DT|DTS|RUL`) was already segment-anchored on main, but the `|DTL|Rule` aliases were still bare substrings — so any path containing `dtl` or `rule` (a repo named `hl7-dtl-mapping/`, a run dir `DTL-BUILD-01/`, a `rules/` folder) fired on every `.cls` beneath it. The aliases are now segment-anchored in the same character class: `[./\\](?:BS|BP|BO|DT|DTS|RUL|DTL|Rule)[./\\]`.

**Bug B — the "a test exists" escape hatch could never succeed under the plugin's own convention.** `tdd/SKILL.md` prescribes `MyApp.Tests.DT.Censo2Menus` → `Tests/DT/Censo2Menus.cls`: a `Tests` package whose basenames carry no "Test" substring. Now: (1) a write whose class/path contains a `Test`/`Tests` segment is exempt (the test file itself is no longer nagged); (2) sibling detection additionally globs `**/Tests/**/*.cls` and `**/Test/**/*.cls`; (3) the target's parent directory joins the search roots, because the documented layout puts `Tests/` **beside** the Tipo dirs, not inside them.

Auxiliary classes (loaders/bootstraps) are excluded by construction — no Tipo segment, no fire — per the issue's suggestion 3.

**Verified with an 11-scenario matrix** (all green), including the issue's exact repros:
- `runs/DTL-BUILD-01-…/src/AdtMap/Bootstrap.cls` → silent (was: fired via run-dir name)
- `src/Eval/DT/LabResult.cls`, no tests → **fires** (was: silent — the case the hook exists for)
- impl with `Tests/DT/` sibling test → silent (was: 19 nags/run)
- writing the `Tests/`-package test itself → silent (was: nagged)
- `.cls` under a `rules/` dir → silent; a real `Rule/` segment class without tests → fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)