### PR TITLE
docs: introspect before the first SQL — table-name resolution as a gate, child-table schema rule

### DIFF
--- a/skills/business-operations/SKILL.md
+++ b/skills/business-operations/SKILL.md
@@ -150,6 +150,7 @@ Switch to UPSERT (`INSERT ... ON CONFLICT (paciente_id) DO NOTHING` / `DO UPDATE
 ## Common pitfalls
 
 - **Concatenating values into SQL strings** instead of parameterizing → injection + escaping bugs.
+- **Writing SQL from an assumed table name, then guessing a different name on `-30`** → resolve the real name first (`iris_table_info` / the `introspect-dont-guess` agent); after a not-found, the next call is introspection, never another guess. See "Resolve real table names BEFORE the first query".
 - **Forgetting `MessageMap`** → every request hits the default `OnMessage` method which then has to dispatch by type manually.
 - **PoolSize > 1 with order-sensitive HL7 receivers** → out-of-order delivery breaks downstream state.
 - **Hardcoding URLs/credentials** instead of using settings + credentials records → environment-specific deploys fail.
@@ -165,6 +166,32 @@ Switch to UPSERT (`INSERT ... ON CONFLICT (paciente_id) DO NOTHING` / `DO UPDATE
 3. From the Management Portal "Test" link on the BO, send a sample message. Or invoke from a Message Router.
 4. Use `message-search-debug` Visual Trace — confirm the BO received, attempted, and got an ACK/response from the destination.
 5. Negative test: stop the destination. Confirm the BO retries per its configured retry policy and surfaces a clear error.
+
+## Resolve real table names BEFORE the first query — introspect, don't guess
+
+Any SQL a BO (or its verification step) touches goes through this gate: **before the first
+`iris_query` / SQL statement against a table you did not create in this session, resolve the real
+name** — `iris_table_info` on the schema, or spawn the `introspect-dont-guess` agent. Never write
+the query from an assumed name.
+
+Measured over a workshop cohort: `iris_query` returned `SQL_ERROR` **127 times across 17/18
+students**, dominated by invented object names — and the recovery pattern made it worse: guess →
+`SQLCODE -30 Table not found` → guess a *different* name → `-30` again (or `-12`, malformed SQL
+written from the same guess), without ever calling the catalog. One introspection call would have
+answered each of these.
+
+The two most-guessed-wrong families:
+
+- **Projected child tables.** A collection property (`Property Alergias As list Of %String` on
+  `COCINA.MSG.MenuRecibido`) projects to a child table **in the parent's schema**:
+  `COCINA_MSG.MenuRecibido_Alergias`. Guessing `COCINA.MenuRecibido_Alergias` (wrong schema) cost
+  one cohort 12 straight failures. The scheme is predictable — which is exactly why
+  `iris_table_info` answers it in one call. See `messages` (Collections) for the projection rule.
+- **Invented system catalogs.** `%Library.SQLConnection`, `Config.config`, `Ens_Config.Setting` —
+  these do not exist as SQL tables. The typed tools (`check_config`, `iris_production_item`,
+  `iris_interop_query`) are the path; `message-search-debug` has the full table.
+
+**On `-30 Table not found`, the NEXT call is introspection — never another guessed name.**
 
 ## JDBC outbound — wiring checklist
 

--- a/skills/business-services/SKILL.md
+++ b/skills/business-services/SKILL.md
@@ -476,8 +476,13 @@ these IRIS-SQL specifics in mind:
   (`SELECT "Connection" FROM …`). Unquoted, you get SQLCODE -1/-12.
 - **ObjectScript is not SQL.** `iris_query` runs SQL SELECTs only. `set`/`write`/`do`/`##class(...)`,
   `&sql(...)`, and `^global` references are ObjectScript — run them with `iris_execute`, not `iris_query`.
-- **Discover, don't guess.** Before querying, use `iris_table_info` (or `docs_introspect`) to get the
-  real table/column names rather than guessing system-catalog tables.
+- **Discover, don't guess.** Before querying, use `iris_table_info` (or `docs_introspect`, or the
+  `introspect-dont-guess` agent) to get the real table/column names rather than guessing
+  system-catalog tables — and on `SQLCODE -30 Table not found`, the next call is introspection,
+  never a differently-guessed name. Collection properties on a RecordMap `.Record` or message
+  class project to a child table **in the parent's schema** (`COCINA.MSG.MenuRecibido` +
+  `Alergias` → `COCINA_MSG.MenuRecibido_Alergias`, not `COCINA.MenuRecibido_Alergias`) — see
+  `messages` (Collections).
 
 ## See also
 

--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -256,6 +256,15 @@ For HL7 repeating fields (AL1*, NK1*), REST JSON arrays, or any multi-valued sou
 SELECT COUNT(*) FROM <Pkg>_Msg.<Parent>_AlergiasList WHERE <Parent> = :id
 ```
 
+**The child table lives in the parent's schema — that is the half people guess wrong.** The schema
+follows the normal class→table rule (package dots become `_`, last dot separates schema from
+table), and the property name is appended to the *table*: class `COCINA.MSG.MenuRecibido` with
+`Property Alergias As list Of %String` projects to `COCINA_MSG.MenuRecibido_Alergias` — not
+`COCINA.MenuRecibido_Alergias` (a guess that cost one workshop cohort 12 straight
+`SQLCODE -30 Table not found` round-trips). Before querying a projected table you did not just
+create, confirm the name with `iris_table_info` (or the `introspect-dont-guess` agent) — one call
+answers it.
+
 Don't substitute a pipe-string property for a typed collection if downstream consumers want collection semantics — the conversion belongs in the DTL one time, not in every consumer.
 
 For `list Of <ObjectClass>`, the `<ObjectClass>` follows the same rule as any object property — see


### PR DESCRIPTION
Closes #29

`introspect-dont-guess` existed but was not reached before SQL got written: 127 `SQL_ERROR`s across 17/18 students, dominated by invented table names and the guess → `-30` → different-guess loop. Both suggested fixes applied:

**1. Routing — introspection phrased as a gate in the skills that lead to SQL:**
- `business-operations` gets a dedicated section — **"Resolve real table names BEFORE the first query — introspect, don't guess"** — placed before the JDBC wiring checklist: before the first `iris_query` against any table not created this session, resolve the name via `iris_table_info` / the `introspect-dont-guess` agent; and the hard rule **"on `-30 Table not found`, the NEXT call is introspection — never another guessed name"** (the loop pattern is what burned the round-trips). Plus a Common-pitfalls bullet.
- `business-services`' existing "Discover, don't guess" cheat-sheet bullet strengthened with the same next-call rule and the agent reference.

**2. Content — the most-guessed-wrong family documented:**
- `messages` (Collections) now states the **schema half** of the child-table projection rule, which is the part everyone gets wrong: the child table lives in the *parent's* schema — `COCINA.MSG.MenuRecibido` + `list Of` `Alergias` → `COCINA_MSG.MenuRecibido_Alergias`, not `COCINA.MenuRecibido_Alergias` (the exact guess that cost 12 straight `-30`s in the cohort).
- The invented-system-catalog family (`%Library.SQLConnection`, `Ens_Config.Setting`, …) is pointed at the typed tools with a cross-link to `message-search-debug`'s full table.

Adjacent issue #26 (wrong *namespace*) is deliberately untouched here — this PR is about non-existent *object names* inside the right one, as the issue delineates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)