### PR TITLE
docs: conformance-review routing that survives CLI transfer — trigger vocabulary + mechanical read-this-file mandate

### DIFF
--- a/skills/conformance-review/SKILL.md
+++ b/skills/conformance-review/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: conformance-review
-description: Review an already-built IRIS Interoperability production against the iris-interop best-practice criteria AFTER implementation + TDD, and report what does not conform with the canonical fix. Use after building/modifying components, before declaring done, or whenever the user asks "is this implemented correctly / per best practices / conforme". This skill is the single source of truth for the conformance criteria (CR-1…CR-12); the `conformance-reviewer` agent and the `conformance-prescan` hook both check against it. Triggers EN: review, conformance, best practices, is this correct, code review, ready to ship. Triggers ES: revisar, conformidad, buenas prácticas, está bien implementado, cumple, revisión.
+description: Review an already-built IRIS Interoperability production against the iris-interop best-practice criteria AFTER implementation + TDD, and report what does not conform with the canonical fix. For ANY review, audit, or quality/conformance check of interop work, read THIS skill FIRST — the criteria (CR-1…CR-12) live here, not in the router or the build skills, and a review run without them is graded incomplete. Use after building/modifying components, before declaring done, or whenever the user asks whether the implementation is correct, idiomatic, or per best practices. The `conformance-reviewer` agent and the `conformance-prescan` hook both check against this file. Triggers EN: review, audit, conformance, best practices, is this correct, is this idiomatic, code review, quality check, check my production, validate the implementation, ready to ship. Triggers ES: revisar, auditar, auditoría, conformidad, buenas prácticas, está bien implementado, es correcto, cumple, revisión, control de calidad.
 ---
 
 # IRIS Interoperability — Conformance Review
+
+> **This file is the review.** However you arrived here — the Skill tool, a native-skill search,
+> or reading `skills/conformance-review/SKILL.md` directly — this document is self-contained:
+> follow its workflow and check its criteria. Do NOT run an interop review from the router or the
+> build skills alone; they do not carry the criteria, and a review without CR-1…CR-12 misses the
+> checks this plugin exists to make.
 
 A built production can **compile and "pass tests"** and still be non-idiomatic. This skill defines the
 criteria a finished interop build is checked against, and the **review workflow**: surface findings →

--- a/skills/interop/SKILL.md
+++ b/skills/interop/SKILL.md
@@ -124,7 +124,7 @@ System Default Settings are the **only** layer that does NOT migrate via a produ
 | **Securing endpoints** — SAML 2.0 / 1.1, OAuth 2.0 server + LDAP, SSL/TLS chain, internal account hygiene | `iris-interop-skills:security` |
 | **Alert circuit** — `Ens.Alert` router, dedup function set, ProductionMonitorService, per-BO alert settings | `iris-interop-skills:alerting` |
 | **About to build *anything* (DTL, rule, BO method, BPL) — TDD workflow** | **`iris-interop-skills:tdd`** (entry point; non-negotiable) |
-| **Built it and TDD-green — is it idiomatic / per best practices?** (run before declaring done) | **`iris-interop-skills:conformance-review`** (criteria CR-1…CR-12; the `conformance-reviewer` agent runs it) |
+| **Built it and TDD-green — is it idiomatic / per best practices?** (run before declaring done) | **`iris-interop-skills:conformance-review`** (criteria CR-1…CR-12; the `conformance-reviewer` agent runs it). **Mechanically: FIRST open `skills/conformance-review/SKILL.md`** — via the Skill tool where available, else read the file — before writing any review output. |
 | %UnitTest framework toolbox (storage, runner flags, ^UnitTest.Result) | `iris-interop-skills:unit-tests` (lower-level reference; the TDD skill calls into it) |
 | Anything DICOM (C-STORE, C-FIND, C-MOVE, MWL, STOW-RS, modalities, PACS) | `iris-interop-skills:dicom` (architecture + wiring patterns; defers byte-level work to docs + vendored sample at `${CLAUDE_PLUGIN_ROOT}/BestPractices/external/workshop-iris-dicom-interop/`) |
 
@@ -152,6 +152,10 @@ involved, issue several `Skill(...)` calls in the same turn.
 - Custom HL7 schema → `Skill(iris-interop-skills:hl7-schemas)`; lookup tables → `Skill(iris-interop-skills:lookup-tables)`.
 - **Any look at a running production** — verifying a run landed, searching messages, tracing a session,
   resending → `Skill(iris-interop-skills:message-search-debug)`. Checking your own work counts.
+- **Any review / audit / conformance or best-practices check** of built interop work →
+  `Skill(iris-interop-skills:conformance-review)` — and in an environment without the Skill tool,
+  **FIRST read `skills/conformance-review/SKILL.md`**. The criteria live in that file only; a review
+  run from this router or the build skills alone is incomplete by construction.
 - FHIR → `Skill(iris-interop-skills:fhir)`; endpoint security → `Skill(iris-interop-skills:security)`;
   alert circuit → `Skill(iris-interop-skills:alerting)`; DICOM → `Skill(iris-interop-skills:dicom)`.
 
@@ -188,7 +192,7 @@ For a typical end-to-end interface, work in this order — it minimises rework b
 9. **Production wiring + settings** (`production-lifecycle`) — add `TestingEnabled="true"` for dev productions; choose deployment tool early
 10. **Security** (`security`) — only after components exist; SAML/OAuth/SSL added where the endpoints actually call out
 11. **Test, search, debug** (`message-search-debug`) — Visual Trace + Event Log for verifying end-to-end runs; purge task added
-12. **Conformance review** (`conformance-review`) — once built and TDD-green, review against the best-practice criteria (CR-1…CR-12) before declaring done; spawn the `conformance-reviewer` agent. It re-verifies tests via the real `iris_test` tool (never a self-graded `[SqlProc]`), reports findings with the canonical fix, and proposes a scoped remediation plan.
+12. **Conformance review** (`conformance-review`) — once built and TDD-green, review against the best-practice criteria (CR-1…CR-12) before declaring done; spawn the `conformance-reviewer` agent, or where no agent/Skill tool exists, FIRST read `skills/conformance-review/SKILL.md` and follow it. It re-verifies tests via the real `iris_test` tool (never a self-graded `[SqlProc]`), reports findings with the canonical fix, and proposes a scoped remediation plan.
 
 For FHIR-specific work, replace steps 4–7 with the `fhir` decision tree (Façade vs Repository, OAuth2 PKCE setup, FHIR R4 Bundle shape).
 


### PR DESCRIPTION
Closes #25

Under Codex native skills, explicit conformance-review prompts loaded the skill in only 3/10 runs — the router loaded 8/10 times but its descriptive companion mention didn't transfer into a second hop. Both suggested directions applied:

**`conformance-review/SKILL.md`:**
- **Description strengthened with review-intent vocabulary** so a native `skill_search` ranks it for review asks without the router hop: *review, audit, conformance, best practices, is this correct, is this idiomatic, code review, quality check, check my production, validate the implementation, ready to ship* (+ ES equivalents incl. *auditar/auditoría*), plus an up-front sentence: for ANY review/audit of interop work, read THIS skill first — the criteria live here, and a review without them is incomplete.
- **New callout under the H1** making the file entry-point-agnostic: however you arrived — Skill tool, native-skill injection, or reading the path directly — this document is self-contained; do not run a review from the router or build skills alone.

**`interop/SKILL.md` (router)** — the companion mandate is now a mechanical instruction in all three places reviews are routed, phrased to survive CLIs with no Skill tool:
- Sibling-index row: "**Mechanically: FIRST open `skills/conformance-review/SKILL.md`** — via the Skill tool where available, else read the file — before writing any review output."
- New "Exact routing" bullet for review/audit/conformance asks, stating the criteria live in that file only and a router-only review is incomplete by construction.
- Build-order step 12: the no-agent/no-Skill-tool fallback named explicitly.

Claude-side behaviour (32/32 fire evidence) is unaffected — the Skill-tool path remains primary; the file-path instruction is additive for skills-only profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)