### PR TITLE
release: 1.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.5.9"
+    "version": "1.6.0"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 6 hooks (SessionStart conventions bootstrap + a PreToolUse conformance gate that blocks non-conformant writes and class loads/compiles smuggled through iris_execute + 4 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.5.9",
+      "version": "1.6.0",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.5.9",
+  "version": "1.6.0",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 6 hooks (SessionStart conventions bootstrap + a PreToolUse conformance gate that blocks non-conformant writes and class loads/compiles smuggled through iris_execute + 4 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Version 1.5.9 → 1.6.0 in `plugin.json` and `marketplace.json` (both fields). Minor bump because runtime hook behaviour changed, alongside new skill content:

**Hooks (behaviour change):**
- `tdd_enforcement.py` rewritten: Tipo-segment matching instead of path substrings; recognises `Tests/`-package tests; parent-dir search root (#32 / issue #27)
- `interop_bootstrap.py` convention (6) widened to full namespace discipline (#35 / issue #26)

**Skills (10 issues since 1.5.9):**
- soap-bo: EnableStandardRequests target, SOAP boolean serialisation (#24)
- production-lifecycle: wait-for-Running, IDKeyExists (#23); refused-start recovery ladder (#33)
- message-search-debug: Search Table authoring (#22)
- business-services: FTPS MLSD/FileSpec-regex (#21)
- transformations: repeating-segment iteration / AL1Count trap (#20)
- business-operations + messages + business-services: introspect-before-SQL gate, child-table schema rule (#34)
- interop + tdd + unit-tests: namespace discipline, server-visible fixture paths (#35)
- conformance-review + interop: routing that survives CLI transfer (#36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)