### PR TITLE
docs: Run() does not bypass ^UnitTestRoot; Parameter PRODUCTION is compile-time mandatory

### DIFF
--- a/skills/component-map/SKILL.md
+++ b/skills/component-map/SKILL.md
@@ -43,7 +43,7 @@ message first (`messages`) and write the test first (`tdd`) as always.
 | Map codes (M→1, planta→edificio, clinic names) | Lookup table + `Lookup()` | imported via Portal / API | — | DTL `Lookup("GeneroSOAP",src.Genero,"")`; code `##class(Ens.Util.LookupTable).%GetValue(tbl,v)`. **Always pass the 3rd default arg.** | `lookup-tables`, `transformations` |
 | Capture production errors to a sink | Alert router + sink BO | `Ens.Rule.Definition` named **`Ens.Alerts`** + `Ens.BusinessOperation` | `EnsLib.File.OutboundAdapter` | router **must** be named `Ens.Alerts`; BO `MessageMap` on `Ens.AlertRequest`; per-item `Send Alert on Error=true` | `alerting` |
 | Make HL7 searchable in Message Viewer | Search Table | `EnsLib.HL7.SearchTable` | — | `XData SearchSpec` `<Item PropName="..">[PID:5()]</Item>` | `hl7-schemas`, `message-search-debug` |
-| Unit-test any interop component | Test | `%UnitTest.TestProduction` (**never** `%UnitTest.TestCase` for productions) | — | `Parameter PRODUCTION`; `TestControl()`→no-op; seed `BaseLogId`; `..SendRequest(...)`; assert the **side-effect**, not just the Event Log | `tdd`, `unit-tests` |
+| Unit-test any interop component | Test | `%UnitTest.TestProduction` (**never** `%UnitTest.TestCase` for productions) | — | `Parameter PRODUCTION` (compile-time mandatory — missing/empty = `#5001`); `TestControl()`→no-op; seed `BaseLogId`; `..SendRequest(...)`; assert the **side-effect**, not just the Event Log | `tdd`, `unit-tests` |
 
 ## The two rules that prevent most wasted round-trips
 

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -11,7 +11,7 @@ description: TDD-first workflow for IRIS Interoperability — the non-negotiable
 
 **Test classes for Interop ALWAYS extend `%UnitTest.TestProduction`**, never plain `%UnitTest.TestCase`. The TestProduction superclass provides everything you'd otherwise reinvent:
 
-- **`Run()` / `Debug()` class methods**: invoke a single test class directly — `do ##class(My.Tests.X).Run()`. **Bypasses the directory-walker pitfall** of `%UnitTest.Manager.RunTest()` that requires `^UnitTestRoot`. No `/noload` gymnastics, no custom helper.
+- **`Run()` / `Debug()` class methods**: invoke a single test class directly — `do ##class(My.Tests.X).Run()`. No `/noload` gymnastics, no custom helper — but **no bypass of the manager either**: `Run()` is a four-line wrapper over `%UnitTest.Manager.DebugRunTestCase`, so **`^UnitTestRoot` must still point at a directory that exists on the IRIS server**. If it doesn't, the run *appears to complete* having discovered **zero test cases** — the `#5007` directory error is buried in the log, so the symptom looks like "no tests found", not like a path problem. See `unit-tests` for the workaround (point it at any existing server-side dir; the MCP's `iris_test` sets it for you).
 - **`SendRequest(name, req, .resp, getReply, timeout)`**: wrapper over `EnsLib.Testing.Service.SendTestRequest`. One line instead of manual `$$$EnsRuntimeAppData` polling.
 - **`GetEventLog(type, configName, baseId, .Log, .new)`**: pulls `Ens_Util.Log` entries into an array, incremental. Type can be `info`, `error`, `warning`, `infouser`, `trace`, `alert`, `assert`, `startstop`, `other`. Replaces hand-written SQL embedded.
 - **`ChangeSetting(production, configName, setting, value)`** / **`GetSetting(...)`**: read/modify production item settings with validation.
@@ -20,14 +20,34 @@ description: TDD-first workflow for IRIS Interoperability — the non-negotiable
 - **Auto-properties**: `MainDir`, `HL7InputDir`, `HL7OutputDir`, `HL7WorkDir`, `HL7ArchiveDir`, `MachineName`, `InstanceName`, `DSNToSamples`, `DSNToUser`, `BaseLogId`, `LastLogId`.
 - **`CheckEnvironment`**: refuses to compile if the namespace is not Interop/HealthShare-enabled (catches setup errors early).
 
-### Required parameters
+### Required parameters — `PRODUCTION` is COMPILE-TIME mandatory
 
 ```objectscript
 Class My.Tests.X Extends %UnitTest.TestProduction
 {
-Parameter PRODUCTION = "My.Production";   ; required by the superclass
+Parameter PRODUCTION = "My.Production";   ; compile fails without it — see below
 }
 ```
+
+The superclass enforces this with a method generator (`CheckParameterPRODUCTION`): a subclass
+whose `PRODUCTION` is **missing or empty (`= ""`)** does not compile:
+
+```
+ERROR #5001: Parameter PRODUCTION must be specified
+  > ERROR #5490: Error running generator for method 'CheckParameterPRODUCTION:...'
+```
+
+Two consequences that are easy to get wrong (verified on IRIS 2026.1):
+
+- **A class that hit `#5001` never compiled, so to the test runner it does not exist.** If you
+  miss the compile error, the *next* thing you see is `iris_test` answering `NO_TESTS_FOUND` —
+  which is a **correct answer about a class that was never created**, not a discovery or naming
+  problem. `%Dictionary.CompiledClass` can still list the class name, which is exactly why this
+  masquerades as a discovery bug. Never diagnose `NO_TESTS_FOUND` without re-reading the last
+  compile result first.
+- The value must be **non-empty**, but it need not name an *existing* production to compile —
+  existence is asserted at runtime when the lifecycle starts the production. Name the real
+  production anyway; a wrong name just moves the failure to run time.
 
 ### When the production is managed externally
 
@@ -135,7 +155,7 @@ against an implementation that silently drops every field.
 
 ## Where to store the tests
 
-`MyApp.Tests.*` package, compiled in the namespace alongside `MyApp.*`. Source-controlled in Git (VS Code ObjectScript export or `$system.OBJ.Export`). With `%UnitTest.TestProduction.Run()` you don't need `^UnitTestRoot` or `/noload` — invoke directly by class name.
+`MyApp.Tests.*` package, compiled in the namespace alongside `MyApp.*`. Source-controlled in Git (VS Code ObjectScript export or `$system.OBJ.Export`). With `%UnitTest.TestProduction.Run()` you don't need `/noload` gymnastics — invoke directly by class name. You **do** still need `^UnitTestRoot` pointing at an existing server-side directory: the manager's "Finding directories" step runs regardless, and an invalid path yields a **silent zero-test run** (see `unit-tests`). The MCP's `iris_test` sets `^UnitTestRoot` itself; the trap bites direct `Run()` / `DebugRunTestCase` invocations.
 
 ## Canonical skeletons (USE THESE AS TEMPLATES)
 
@@ -332,9 +352,12 @@ For runner mechanics — the `^UnitTestRoot` directory requirement, `DebugRunTes
 a compiled test class under the name you passed. Re-running the identical call will return the identical
 error. Work the cause instead, in this exact order:
 
-1. **Compile the test class FIRST, then run it.** The class must be compiled before `iris_test` can see
-   it. Push it with `iris_doc(mode=put, compile=true)` (or `iris_compile`) and confirm a clean compile —
-   a test class that failed to compile does not exist to the runner.
+1. **Re-read the last compile result, then compile the test class and confirm it is CLEAN.** The class
+   must be compiled before `iris_test` can see it. Push it with `iris_doc(mode=put, compile=true)` (or
+   `iris_compile`) and **read the compiler output — do not assume**: a test class that failed to compile
+   does not exist to the runner, even though `%Dictionary.CompiledClass` may still list its name. The
+   most common compile failure on a `TestProduction` subclass is
+   `ERROR #5001: Parameter PRODUCTION must be specified` — see "Required parameters" above.
 2. **Run `iris_test` with the EXACT compiled class name** — fully qualified, case-correct
    (`MyApp.Tests.DT.Censo2Menus`, not `Censo2Menus`, not `myapp.tests...`). An unqualified or
    mis-cased name is the most common cause.
@@ -345,8 +368,10 @@ error. Work the cause instead, in this exact order:
    and have at least one `Test*` method. A class that extends the wrong base, or whose methods are not
    prefixed `Test`, compiles but exposes zero tests.
 5. Only after 1–4 — if it still reports `NO_TESTS_FOUND` — STOP and report the blocker (see the agent's
-   iteration cap). Do not loop, and do not switch to `$SYSTEM.OBJ.Load` / the terminal to "work around"
-   it: that does not change what the runner sees.
+   iteration cap). Do not loop, and do not switch routes to "work around" it — not `$SYSTEM.OBJ.Load` /
+   the terminal, not `Run()` via `iris_execute`, not `RunTest(..., "/noload")`, not querying
+   `^UnitTest.Result` by hand hoping to find a result. Every one of those gives the same (correct)
+   answer about a class that never compiled; the only fix is upstream, at step 1.
 
 ### After running — show the portal URL (ALWAYS)
 
@@ -380,6 +405,7 @@ See `business-operations` and `bpl` for the runtime side of the same rule.
 ## Pitfalls specific to Interop TDD
 
 - **Extending `%UnitTest.TestCase` instead of `%UnitTest.TestProduction`** — you lose `Run()`, `SendRequest`, `GetEventLog`, etc., and end up reinventing them with `$$$EnsRuntimeAppData` polling and embedded SQL. Don't.
+- **Omitting `Parameter PRODUCTION` (or leaving it `= ""`)** — the class fails to compile with `#5001`, and everything downstream (`iris_test` → `NO_TESTS_FOUND`, empty `^UnitTest.Result`) is a correct report about a class that doesn't exist. Measured across an eval campaign, this single omission accounted for **every** zero-tests-run failure while the class *looked* complete. Non-empty is the compile-time requirement; naming the real production is the runtime one.
 - **Stubbing the adapter in BO tests.** In conventional software you'd unit-test the BO method with a mocked adapter — in IRIS Interop that's an anti-pattern. The adapter boundary is exactly where the defects you care about live (auth, classpath, type marshalling, encoding, timeouts). Stubs make the test green while the real thing breaks. Use a real adapter against a real test endpoint.
 - **Forgetting to override `TestControl()`** — TestProduction will start/stop your production every time you `Run()`. Override to no-op when the production is managed externally.
 - **Forgetting to seed `..BaseLogId`** — `GetEventLog` returns nothing if `BaseLogId` is empty. Seed it in `OnBeforeAllTests` from `MAX(ID) FROM Ens_Util.Log`.
@@ -415,11 +441,11 @@ Default to **prefix** unless you have a concrete reason to escalate. Auditing a 
 
 ```
 Test classes:   extend %UnitTest.TestProduction (never plain TestCase).
-Parameter:      PRODUCTION = "MyApp.Production"
+Parameter:      PRODUCTION = "MyApp.Production"   — COMPILE-TIME mandatory; missing/empty = #5001, class never exists
 Lifecycle:      override TestControl() to no-op if production runs externally; seed ..BaseLogId in OnBeforeAllTests.
 Dispatch:       ..SendRequest(configName, req, .resp, getReply, timeout)
 Inspect:        ..GetEventLog(type, configName, baseId, .Log, .new)
-Run:            do ##class(MyApp.Tests.X).Run()
+Run:            do ##class(MyApp.Tests.X).Run()   — still needs ^UnitTestRoot → existing server dir (unit-tests)
 
 Spec → Test → Red → Implement → Green → Refactor.
 BS: from outside IRIS only (file drop, TCP, curl).

--- a/skills/unit-tests/SKILL.md
+++ b/skills/unit-tests/SKILL.md
@@ -8,7 +8,7 @@ description: %UnitTest framework - runner, storage, results. Routed from interop
 > **Workflow note**: for the *order of work* (spec → test → red → implement → green → refactor) and for **the baseline class you must extend** (`%UnitTest.TestProduction`, not `%UnitTest.TestCase`), see **`tdd`**. That's the entry point when you're starting a new Interop component. This skill is the lower-level reference for **how the framework itself works**: where tests live on disk, how to invoke runners, where results land, how to inspect them.
 
 IRIS ships a built-in unit-test framework with two relevant classes:
-- **`%UnitTest.TestProduction`** — the Interop-flavoured superclass. **Use this for any Interop test.** Provides `Run()`, `SendRequest`, `GetEventLog`, `ChangeSetting`, `CreateCredentials`, file helpers, auto-properties (`BaseLogId`, `HL7InputDir`, etc.). Detail in `tdd`.
+- **`%UnitTest.TestProduction`** — the Interop-flavoured superclass. **Use this for any Interop test.** Provides `Run()`, `SendRequest`, `GetEventLog`, `ChangeSetting`, `CreateCredentials`, file helpers, auto-properties (`BaseLogId`, `HL7InputDir`, etc.). Detail in `tdd`. **Its `PRODUCTION` parameter is compile-time mandatory**: a method generator fails the compile of any subclass with a missing or empty value (`ERROR #5001: Parameter PRODUCTION must be specified`) — after which every runner correctly reports zero tests, because the class never compiled.
 - **`%UnitTest.TestCase`** — the generic base. **Only use directly for tests of pure utility code that has nothing to do with Interop** (and even then, extending TestProduction is fine if the namespace is Interop-enabled).
 
 ## When to use this skill
@@ -32,7 +32,7 @@ Two patterns:
    do ##class(MyApp.Tests.DT.X).Debug()    ; same-process, stops on failure for inspection
    ```
 
-   **`Run()` still requires `^UnitTestRoot` to point at an existing directory** — even though we're not loading from it, the manager calls "Finding directories" early and fails with `ERROR #5007` if the path is invalid. Workaround:
+   **`Run()` still requires `^UnitTestRoot` to point at an existing directory** — even though we're not loading from it, the manager calls "Finding directories" early and fails with `ERROR #5007` if the path is invalid. **The failure does not look like a path problem**: the `#5007` is only in the run's log output, and the manager still records a result — with **zero test cases**. Anything that reads only the recorded result (a harness, a wrapper, `^UnitTest.Result`) sees "run completed, no tests found", indistinguishable from a discovery or naming issue. (The MCP's `iris_test` sets `^UnitTestRoot` itself before running — this trap bites direct `Run()` / `DebugRunTestCase` invocations via `iris_execute`, the terminal, or external harnesses.) Workaround:
 
    ```objectscript
    set ^UnitTestRoot = "C:\Temp\unittest_fake"
@@ -238,7 +238,8 @@ For Interop-specific test skeletons (DTL / routing rule / BO method / BPL), see 
 ## Common pitfalls
 
 - **Tests stored where the runner deletes them after run** — pick a storage pattern that doesn't get cleaned up (see "Where to store" above).
-- **`Run()` failing with `ERROR #5007: Finding directories`** — `^UnitTestRoot` not set or points at a non-existent path. Set it to any existing directory; runner reads no files from it.
+- **`Run()` failing with `ERROR #5007: Finding directories`** — `^UnitTestRoot` not set or points at a non-existent path (server-side!). Set it to any existing directory; runner reads no files from it. Remember the symptom is usually **not** the `#5007` itself but a run that "completes" with zero test cases — check `^UnitTestRoot` before chasing discovery hypotheses.
+- **`#5001: Parameter PRODUCTION must be specified` at compile time** — every `%UnitTest.TestProduction` subclass must declare a **non-empty** `Parameter PRODUCTION` (a method generator enforces it; verified on IRIS 2026.1). The value need not name an existing production *to compile* — existence is asserted at runtime when the lifecycle starts the production. A class that hit this error never compiled, so a later `NO_TESTS_FOUND` is the correct answer about a missing class, not a discovery bug — re-read the compile output before touching anything else.
 - **Qualifier syntax `/noload=0`** → `#5001: can not mix negated form with value`. Boolean qualifiers are presence-only.
 - **`Quit <value>` inside `Try`** → `#1043`. Set tSC; exit Try; quit after.
 - **Asserting on internal state instead of public contract** — tests get brittle. Assert on what the next consumer (DTL, BO, downstream system) will actually see.


### PR DESCRIPTION
## Summary

Fixes the two open skill-defect issues, both of which produce a **silent zero-tests-run failure that masquerades as a discovery problem**:

- **Fixes #39** — `tdd` claimed `Run()`/`Debug()` "bypass the directory-walker pitfall" of `^UnitTestRoot` (lines 14 and 138). Wrong: `Run()` is a four-line wrapper over `%UnitTest.Manager.DebugRunTestCase`, so `^UnitTestRoot` must still point at an existing **server-side** directory. `tdd` now matches `unit-tests` (which was already correct), and both skills state the misleading symptom explicitly: an invalid root yields a run that *appears to complete with zero test cases* — the `#5007` is only in the log. Also documented: the MCP's `iris_test` sets `^UnitTestRoot` itself, so the trap bites direct `Run()`/`DebugRunTestCase` invocations (via `iris_execute`, terminal, or external harnesses).

- **Fixes #38** — nothing in the skills said `Parameter PRODUCTION` is **mandatory at compile time**. A `%UnitTest.TestProduction` subclass with it missing or empty fails to compile (`ERROR #5001: Parameter PRODUCTION must be specified`, via the `CheckParameterPRODUCTION` method generator); the class then never exists, so a later `NO_TESTS_FOUND` is a *correct answer about a class that was never created* — even though `%Dictionary.CompiledClass` may still list the name, which is why agents chased discovery hypotheses instead.

## Changes

**`skills/tdd/SKILL.md`**
- Superclass feature list + "Where to store the tests" + TL;DR: corrected the `^UnitTestRoot` claims, with the silent symptom named.
- "Required parameters" section rewritten: leads with *compile-time mandatory*, quotes the `#5001` signature verbatim, notes the value need only be **non-empty** to compile (production existence is a runtime assert — name the real one anyway).
- `NO_TESTS_FOUND` recovery recipe: step 1 now starts from **re-reading the compile output** and names `#5001` as the most common cause; step 5 now bans the exact dead-end workaround routes the failing eval runs took (`Run()` via `iris_execute`, `RunTest(...,"/noload")`, hand-querying `^UnitTest.Result`).
- New pitfall bullet for the missing/empty `PRODUCTION` case.

**`skills/unit-tests/SKILL.md`**
- `TestProduction` description and a new pitfall bullet carry the `#5001` compile-time mandate.
- Both `^UnitTestRoot` passages now state the zero-test-cases symptom and that `iris_test` sets the global itself.

**`skills/component-map/SKILL.md`**
- Test row: compact "(compile-time mandatory — missing/empty = `#5001`)" note.

## Verification

Both mechanisms verified live on IRIS 2026.1 (irishealth-community, via the MCP):
- `TestProduction` subclass without `PRODUCTION` → `ERROR #5001: Parameter PRODUCTION must be specified` / `#5490` generator error, class not compiled.
- Same class with `PRODUCTION = "Does.Not.Exist.Production"` → compiles clean.
- Grep confirms no contradictory `^UnitTestRoot` claim remains anywhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)