### PR TITLE
release: 1.6.1 — correct stale counts in README/CLAUDE.md/manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.6.0"
+    "version": "1.6.1"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
-      "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 6 hooks (SessionStart conventions bootstrap + a PreToolUse conformance gate that blocks non-conformant writes and class loads/compiles smuggled through iris_execute + 4 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.6.0",
+      "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
+      "version": "1.6.1",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.6.0",
-  "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 6 hooks (SessionStart conventions bootstrap + a PreToolUse conformance gate that blocks non-conformant writes and class loads/compiles smuggled through iris_execute + 4 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
+  "version": "1.6.1",
+  "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",
     "url": "https://github.com/intersystems-ib"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,9 +21,11 @@ sibling skill for each task. Always load `iris-interop-skills:tdd` as a companio
   The router (`interop`) refers to its siblings by their **plugin-qualified id**
   `iris-interop-skills:<name>` (e.g. `iris-interop-skills:messages`), not by bare
   name or path — a bare `Skill("messages")` errors with "Unknown skill".
-- `agents/*.md` — three bundled subagents (`interop-builder`, `deploy-smoke-test`,
-  `introspect-dont-guess`) that auto-register on install. MCP-server-agnostic (no server pinned).
-- `hooks/` — two PostToolUse hooks (silent-execute guard, TDD enforcement) auto-enabled via `plugin.json`.
+- `agents/*.md` — four bundled subagents (`interop-builder`, `deploy-smoke-test`,
+  `introspect-dont-guess`, `conformance-reviewer`) that auto-register on install. MCP-server-agnostic (no server pinned).
+- `hooks/` — eight hooks auto-enabled via `plugin.json`: a SessionStart conventions bootstrap,
+  two blocking PreToolUse gates (conformance gate, src-before-iris), and five PostToolUse guards
+  (silent-execute guard, TDD enforcement, conformance pre-scan, docker-detect, tdd-first-green).
 - **Required user setting:** raise the skill-listing budget (`skillListingBudgetFraction: 0.03`,
   `skillListingMaxDescChars: 2048`) in `~/.claude/settings.json` so `interop`/`tdd` don't get evicted.
 - `BestPractices/` — the worked-example bank the skills cite:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # iris-interop-skills
 
-A set of **19 Claude Code skills** for building **InterSystems IRIS For Health
+A set of **20 Claude Code skills** for building **InterSystems IRIS For Health
 Interoperability** productions — and a bank of worked examples and best practices
 distilled from real-world integration projects.
 
@@ -104,8 +104,9 @@ self-contained binary.
    /plugin install iris-interop-skills@iris-interop-skills
    ```
 
-   This installs everything that ships with the plugin: the **20 skills**, the four **hooks**
-   (silent-execute guard + TDD enforcement + docker-detect + conformance pre-scan — auto-enabled), and
+   This installs everything that ships with the plugin: the **20 skills**, the eight **hooks**
+   (a SessionStart conventions bootstrap, two PreToolUse gates that can block non-conformant calls,
+   and five PostToolUse guards — auto-enabled; see *Hooks* below), and
    the four **agents** (`interop-builder`, `deploy-smoke-test`, `introspect-dont-guess`,
    `conformance-reviewer` — auto-registered; see *Agents* below).
 
@@ -225,7 +226,7 @@ the `iris-agentic-dev` or `iris-interop-dev` MCP.
   for the trickier patterns, indexed by rule in `examples/README.md`. Several
   skills cite these as concrete worked examples.
 - `external/workshop-iris-dicom-interop/` — a vendored MIT snapshot of the
-  InterSystems Iberia DICOM-interop workshop, used by `iris-interop-dicom`.
+  InterSystems Iberia DICOM-interop workshop, used by the `dicom` skill.
 
 All customer-identifying provenance has been removed from this public edition;
 the patterns are vendor-neutral.
@@ -254,16 +255,23 @@ Raise the budget in your **own** settings — `~/.claude/settings.json` (user) o
 
 ## Hooks
 
-Four `PostToolUse` hooks ship in `hooks/` and auto-enable when the plugin is installed (wired via
-`hooks/hooks.json`, referenced from `plugin.json`). They are **advisory** (they never block) and
-need a Python interpreter on PATH — resolved as **`python3` → `python` → `py`** (so Windows, where
-the interpreter is `python`/`py` rather than `python3`, works too); if none is found they degrade to a no-op.
+Eight hooks ship in `hooks/` and auto-enable when the plugin is installed (wired via
+`hooks/hooks.json`, referenced from `plugin.json`). They need a Python interpreter on PATH —
+resolved as **`python3` → `python` → `py`** (so Windows, where the interpreter is `python`/`py`
+rather than `python3`, works too); if none is found they degrade to a no-op. The two `PreToolUse`
+gates can **block** a non-conformant call; the SessionStart bootstrap and the five `PostToolUse`
+guards are advisory.
 
-| Hook | Fires on | What it does |
-|---|---|---|
-| `silent-execute-guard` | `iris_execute` returning empty output (`success:true`, no captured output) | Reminds that HTTP CodeMode returns only what you `write`; wrap side-effecting code as a `[SqlProc]` and SELECT it, or verify with `iris_query`. |
-| `tdd-enforcement` | `Write`/`Edit` of a `*.BO.*` / `*.BP.*` / `*DTL*` / `*Rule*` `.cls` with no sibling `*Test*.cls` | Reminds to write the test first (spec → test → red → implement → green; tests extend `%UnitTest.TestProduction`). |
-| `docker-detect` | An interop tool returns `DOCKER_REQUIRED` | Reminds that the instance is native/remote — the tools work over HTTP; retry without `IRIS_CONTAINER`. |
+| Hook | Event | Fires on | What it does |
+|---|---|---|---|
+| `interop-bootstrap` | `SessionStart` | every session | Injects the core interop conventions (naming, adapter rule, router rule, MCP-only, TDD) so they hold even before any skill loads. |
+| `interop-conformance-gate` | `PreToolUse` (**blocking**) | IRIS write/execute tools (`iris_doc`, `iris_compile`, `iris_execute`, production / credential / lookup tools) | Blocks convention violations — wrong class naming, extending the adapter, hand-`OnRequest` routing — and class loads/compiles smuggled through `iris_execute`. |
+| `src-before-iris` | `PreToolUse` (**blocking**) | `iris_doc(mode=put)` | The filesystem is the source of truth: the class must exist under `src/` before it is pushed to the namespace. |
+| `silent-execute-guard` | `PostToolUse` | `iris_execute` returning empty output (`success:true`, no captured output) | Reminds that HTTP CodeMode returns only what you `write`; wrap side-effecting code as a `[SqlProc]` and SELECT it, or verify with `iris_query`. |
+| `tdd-enforcement` | `PostToolUse` | `Write`/`Edit`/`iris_doc(put)` of a `*.BO.*` / `*.BP.*` / `*DTL*` / `*Rule*` `.cls` with no sibling `*Test*.cls` | Reminds to write the test first (spec → test → red → implement → green; tests extend `%UnitTest.TestProduction`). |
+| `conformance-prescan` | `PostToolUse` | `Write`/`Edit`/`iris_doc(put)` of an interop `.cls` | Cheap, deterministic pre-screen of that one file against the `conformance-review` criteria. |
+| `docker-detect` | `PostToolUse` | An interop tool returns `DOCKER_REQUIRED` | Reminds that the instance is native/remote — the tools work over HTTP; retry without `IRIS_CONTAINER`. |
+| `tdd-first-green` | `PostToolUse` | `iris_test` | Detects test-after-code: a test class whose **first ever** run is green never went red, so it proves nothing — asks for one currently-failing case. |
 
 Not installing as a plugin? Add the equivalent `hooks` block to your `settings.json`, pointing at
 the `hooks/*.sh` wrappers.
@@ -278,7 +286,7 @@ the `hooks/*.sh` wrappers.
   ES/EN); and (b) the **bare-vs-qualified invocation trap** — `Skill("interop")` errors with
   "Unknown skill" while `Skill("iris-interop-skills:interop")` works (the router + CLAUDE.md now
   always use the qualified id, and the router lists the exact `Skill(...)` calls to make).
-- **No skill was removed.** All 17 are intentional.
+- **No skill was removed.** All 20 are intentional.
 
 ## License
 


### PR DESCRIPTION
## Summary

Documentation-accuracy release following the `tdd`/`unit-tests` fixes (#40). Verified every count and claim in the README against the repo's actual contents; several were stale.

## Corrections

**README.md**
- Headline said **"19 Claude Code skills"** — there are **20** (the skills table already listed all 20 correctly; `ls skills/ | wc -l` = 20).
- Install blurb + Hooks section claimed **four** advisory `PostToolUse` hooks that "never block", and the table listed only three. `hooks/hooks.json` actually wires **eight**: a `SessionStart` conventions bootstrap, **two `PreToolUse` gates that can deny** (`interop-conformance-gate`, `src-before-iris` — both emit `"deny"` decisions), and five `PostToolUse` guards (`silent-execute-guard`, `tdd-enforcement`, `conformance-prescan`, `docker-detect`, `tdd-first-green`). The Hooks table now lists all eight with event, trigger, and blocking/advisory status.
- Decision log said "All **17** are intentional" (pre-dates the count reaching 20) → 20.
- Stale skill name `iris-interop-dicom` → the `dicom` skill.

**CLAUDE.md**
- Said **three** bundled subagents (there are **four** — `conformance-reviewer` was missing) and **two** PostToolUse hooks → corrected to the eight-hook breakdown.

**plugin.json / marketplace.json**
- Descriptions said "6 hooks … 4 PostToolUse guards" → "8 hooks … 2 PreToolUse gates … 5 PostToolUse guards", now mentioning the `src-before-iris` gate.

## Version

`1.6.0` → **`1.6.1`** in both `plugin.json` and `marketplace.json` (patch bump, matching the repo's precedent of patch releases for documentation fixes — v1.5.1–v1.5.4).

## Verified intact

Skills table enumerates exactly the 20 directories under `skills/`; agents section matches the four files under `agents/`; conformance criteria references (CR-1…CR-12) match `conformance-review`; both manifests parse as valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)