### PR TITLE
docs: try/catch idiom deferred to unit-tests; wire the unused objectscript-trycatch.cls example

### DIFF
--- a/skills/bpl/SKILL.md
+++ b/skills/bpl/SKILL.md
@@ -243,23 +243,7 @@ when MyApp.UTL.AlertFilterFunctions.AlreadyReportedErr(SourceConfigName, AlertTe
 
 ## ObjectScript error-handling idiom inside BPL code blocks
 
-When dropping to ObjectScript inside a BPL `<code>` activity (or in a custom `Ens.BusinessProcess` subclass), use the modern try/catch idiom — wizard-generated code often still uses `$$$ISERR`-style checks but new work should standardise:
-
-```objectscript
-#DIM tSC As %Status = $$$OK
-#DIM errObj As %Exception.AbstractException
-try {
-    $$$THROWONERROR(tSC, ..<MethodName>(<args>))
-    // OR
-    set tSC = ..<MethodName>(<args>)
-    $$$ThrowOnError(tSC)
-} catch (errObj) {
-    set tSC = errObj.AsStatus()
-}
-quit tSC
-```
-
-Always return `%Status`; the BPL framework expects it and surfaces errors correctly.
+When dropping to ObjectScript in a `<code>` activity (or a custom `Ens.BusinessProcess` subclass), wrap the work in try/catch, convert exceptions with `errObj.AsStatus()`, and always return `%Status` — the BPL framework expects it and surfaces errors correctly. Never `Quit <value>` inside the `Try` (`#1043`), and standardise new code on `$$$ThrowOnError` rather than wizard-style `$$$ISERR` chains. Full idiom: `unit-tests` §"Error handling inside test methods"; canonical copy-paste class: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch05_bpl_dtl/objectscript-trycatch.cls` (§5.4 in `examples/README.md`).
 
 ## BPL editor regression: `Missing BPL Data`
 

--- a/skills/transformations/SKILL.md
+++ b/skills/transformations/SKILL.md
@@ -315,23 +315,7 @@ Do **not** assume "vendor A → vendor B" is passthrough without inspecting actu
 
 ## ObjectScript inside DTL `<code>` blocks — use the modern try/catch idiom
 
-When dropping to ObjectScript inside a DTL `<code>` activity, use the standard try/catch idiom so the DTL framework reports failures cleanly:
-
-```objectscript
-#DIM tSC As %Status = $$$OK
-#DIM errObj As %Exception.AbstractException
-try {
-    $$$THROWONERROR(tSC, ..<HelperMethod>(<args>))
-    // OR
-    set tSC = ..<HelperMethod>(<args>)
-    $$$ThrowOnError(tSC)
-} catch (errObj) {
-    set tSC = errObj.AsStatus()
-}
-// tSC is now either OK or an %Status carrying the diagnostic
-```
-
-Always return `%Status` from a helper method called from DTL — the framework expects it and surfaces errors correctly. Wizard-generated code often still uses older `$$$ISERR(...)`-style chains; new code standardises on try/catch with `$$$ThrowOnError`.
+When dropping to ObjectScript inside a DTL `<code>` activity (or a helper method it calls), wrap the work in try/catch, convert exceptions with `errObj.AsStatus()`, and always return `%Status` — the DTL framework expects it and surfaces errors correctly. Never `Quit <value>` inside the `Try` (`#1043`); standardise new code on `$$$ThrowOnError` rather than wizard-style `$$$ISERR(...)` chains. Full idiom: `unit-tests` §"Error handling inside test methods"; canonical copy-paste class: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch05_bpl_dtl/objectscript-trycatch.cls` (§5.4 in `examples/README.md`).
 
 ## When NOT to use this skill — fall back to docs
 

--- a/skills/unit-tests/SKILL.md
+++ b/skills/unit-tests/SKILL.md
@@ -128,15 +128,12 @@ The `DebugRunTestCase` qualifier flags are **boolean** — write `/noload/norecu
 
 ```objectscript
 Set tSC = $$$OK
-Try {
-    ; ... possibly-raising work ...
-} Catch ex {
-    Set tSC = ex.AsStatus()
-}
+Try { Set tSC = ..PossiblyRaisingWork() }
+Catch ex { Set tSC = ex.AsStatus() }
 If $$$ISERR(tSC) Quit tSC
 ```
 
-Set the status inside the Try; exit the Try; then act on it. Same idiom applies in test method bodies (see "Error handling" below).
+Set the status inside the Try; exit the Try; then act on it. Full idiom (with `#DIM`s and `$$$ThrowOnError`) in §"Error handling inside test methods" below.
 
 ## Inspecting results — the `%UnitTest.Portal` web pages
 
@@ -197,9 +194,9 @@ Method TestSomething()
 }
 ```
 
-This is the same pattern used in production code (see `transformations` and `bpl`). Consistent error handling between tests and code means the framework's assertion message includes the real diagnostic chain — not "tSC was 0" with no further context.
+This is the same idiom to use in production code — BPL `<code>` blocks and DTL helper methods defer here (`bpl`, `transformations`). Canonical copy-paste class: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch05_bpl_dtl/objectscript-trycatch.cls` (§5.4 in `examples/README.md`). Consistent error handling between tests and code means the framework's assertion message includes the real diagnostic chain — not "tSC was 0" with no further context.
 
-Inside a `Try` block, `Quit <value>` is illegal (`#1043: QUIT argument not allowed`). Set the status, exit the Try, then act on it after — same as the runner-side rule above.
+Inside a `Try`, `Quit <value>` is illegal (`#1043`) — same rule as the runner-side section above.
 
 ## Canonical pattern — unit-testing a DTL
 


### PR DESCRIPTION
## Summary

First PR of the approved **compact-in-place** refactor: the try/catch `%Status` idiom appeared as near-identical ~19-line code blocks in **three** skills, while the canonical example file `BestPractices/examples/ch05_bpl_dtl/objectscript-trycatch.cls` (indexed as §5.4 in `examples/README.md`) was referenced by **zero** skills.

- **`unit-tests`** becomes the owner (`tdd` already defers runner mechanics there): §"Error handling inside test methods" keeps the full idiom and now carries the `${CLAUDE_PLUGIN_ROOT}` pointer to the canonical class. The duplicated runner-side block compresses to a 4-line skeletal form deferring to the same section.
- **`bpl`** and **`transformations`**: the 19-line blocks are replaced by a complete one-paragraph statement of the rule (try/catch, `errObj.AsStatus()`, always return `%Status`, never `Quit <value>` in `Try` (#1043), `$$$ThrowOnError` over `$$$ISERR` chains) plus pointers to the owner section and the canonical example — so each skill remains self-sufficient on the rule itself, per the plan's constraint.

Verified: `#DIM errObj` now greps only in `unit-tests`; `objectscript-trycatch.cls` referenced exactly once in each of the three skills; the example file exists and matches the taught idiom. Net −35 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)