### PR TITLE
docs: compact intra-file restatements to owning-section pointers

### DIFF
--- a/skills/alerting/SKILL.md
+++ b/skills/alerting/SKILL.md
@@ -171,10 +171,10 @@ These don't replace the alert circuit — they sit alongside it. See `fhir`.
 
 - **`Send Alert on Error` enabled on `Ens.Alert` itself or on the alert sink BO** → infinite alert loop. The portal won't warn.
 - **No dedup function set in `Ens.Alert`** → cascading alerts and retry storms flood the mailbox; oncall starts ignoring the channel.
-- **`Failure Timeout = -1`** → infinite retries pile up against an unreachable target, queue slots leak. Always finite.
+- **`Failure Timeout = -1`** → infinite retries; always finite — see the per-BO settings checklist above.
 - **No `Ens.ProductionMonitorService`** → portal monitor screen stops updating; status feels real-time but is stale.
 - **Disabling `Send Alert on Error` on a "noisy" host** instead of filtering in the router → loses recoverability if the noise was actually a real condition you started ignoring.
-- **Storing the dedup state in `^IRISTemp.*`** → dedup resets on process restart; the next retry storm starts fresh. Use a regular global.
+- **Storing the dedup state in `^IRISTemp.*`** → dedup resets on process restart. Use a regular global (see the dedup function notes above).
 - **Per-occurrence variation in the error message** (PIDs, timestamps, stack frames) defeats simple dedup keys → truncate to first 200 chars or hash the constant prefix.
 
 ## Testing the alert circuit

--- a/skills/business-operations/SKILL.md
+++ b/skills/business-operations/SKILL.md
@@ -114,24 +114,17 @@ Without a finite timeout, in-flight retries against an unreachable target accumu
 
 ### Timeout precedence — BO timeouts MUST be smaller than calling BP
 
-A BO's `Response Timeout` and `Failure Timeout` MUST be smaller than the calling BP's wait timeout. Whoever times out first owns the error context:
-
-- BO times out first → BO raises `Ens.AlertRequest` with diagnostic detail; BP gets the failure and can decide.
-- BP times out first → BO is still processing, never gets to mark its own error; the BP sees a generic timeout with no diagnostic chain.
-
-Set BO timeouts last, after the calling BP's timeout is fixed. See `bpl` for the BP-side view.
+A BO's `Response Timeout` and `Failure Timeout` MUST be strictly smaller than the calling BP's wait timeout — whoever times out first owns the error context, and only a BO-first timeout carries diagnostic detail up the chain. Set BO timeouts last, after the calling BP's timeout is fixed. Mechanism and the BP-side view: see `bpl` §"Timeouts".
 
 ### `ReplyCodeActions` defaults can swallow application errors (HL7 BO)
 
-The default HL7 BO `ReplyCodeActions` (`:?R=RF,:?E=S,:~=S,:?A=C,:*=S,:I?=W,:T?=C`) leaves application-level errors as **Suspended** messages. For integrations that **intentionally** return negative ACKs (rejected admissions, business-rule denials), this turns every business rejection into a suspended message requiring manual operator action.
-
-For HL7 BOs whose calling BP wants to inspect the ACK/NACK itself, override to:
+The default HL7 BO `ReplyCodeActions` (`:?R=RF,:?E=S,:~=S,:?A=C,:*=S,:I?=W,:T?=C`) leaves application-level errors as **Suspended** messages — so an integration that intentionally returns negative ACKs drowns operators in suspended messages. For HL7 BOs whose calling BP wants to inspect the ACK/NACK itself, override to:
 
 ```
 :?R=C,:?E=C,:~=C,:?A=C,:*=C,:I?=C
 ```
 
-This **Completes** the message regardless of reply code; the BP receives the response and decides what to do. See `alerting` for the full decision matrix.
+This **Completes** the message regardless of reply code; the BP receives the response and decides. Symbol meanings + full decision matrix: see `alerting`.
 
 ## Transactions — single row vs batch
 
@@ -150,7 +143,7 @@ Switch to UPSERT (`INSERT ... ON CONFLICT (paciente_id) DO NOTHING` / `DO UPDATE
 ## Common pitfalls
 
 - **Concatenating values into SQL strings** instead of parameterizing → injection + escaping bugs.
-- **Writing SQL from an assumed table name, then guessing a different name on `-30`** → resolve the real name first (`iris_table_info` / the `introspect-dont-guess` agent); after a not-found, the next call is introspection, never another guess. See "Resolve real table names BEFORE the first query".
+- **Writing SQL from an assumed table name, then guessing again on `-30`** → see §"Resolve real table names BEFORE the first query" above.
 - **Forgetting `MessageMap`** → every request hits the default `OnMessage` method which then has to dispatch by type manually.
 - **PoolSize > 1 with order-sensitive HL7 receivers** → out-of-order delivery breaks downstream state.
 - **Hardcoding URLs/credentials** instead of using settings + credentials records → environment-specific deploys fail.
@@ -304,7 +297,7 @@ When a third-party library is only available as Java (legacy SAML modules, custo
 3. Write a BO that extends `EnsLib.JavaGateway.AbstractOperation` and calls the proxy via `obj.<javaMethod>(...)`.
 4. Add the JAR to the JavaGateway classpath via the production component's "Additional parameters" setting.
 
-In 2025+, prefer **External Language Server** references over `EnsLib.JavaGateway.Service` (the gateway class is deprecated in IRIS 2026.1 in favour of ELS-direct references). The JavaGateway BO pattern itself still works but flag it as "use sparingly" — most legacy use cases now have native ObjectScript alternatives (e.g. SAML via `intersystems-ib/SAML-COS` instead of a Java SAML module).
+In 2025+, prefer **External Language Server** references over `EnsLib.JavaGateway.Service` (deprecated in IRIS 2026.1 — deprecation policy in `production-lifecycle` §"Default scaffolds"). Use sparingly: most legacy use cases now have native ObjectScript alternatives (e.g. SAML via `intersystems-ib/SAML-COS`).
 
 Worked example: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch06_adapters/javagateway-bo.cls`.
 
@@ -316,7 +309,7 @@ When integrating with a lab analyzer / device vendor (any modality where HL7 v2 
 - Segment re-ordering (the receiver keys on segment position).
 - Field copying between segments (the receiver's primary key lives in a non-standard field).
 
-Do not assume "vendor A → vendor B" is passthrough without inspecting the actual payloads. Document the DT per direction; see `iris-interop-transformations §2.4`.
+Do not assume "vendor A → vendor B" is passthrough without inspecting the actual payloads. Document the DT per direction; mechanism and concrete cases: `transformations` §"Lab device integration".
 
 Also: document the port pairs per environment in a single integration table, not just in BS/BO settings. Lab integrations are notoriously asymmetric (different ports for PRE vs PRO, different ports for inbound vs outbound) — discovery without a table is painful.
 

--- a/skills/business-services/SKILL.md
+++ b/skills/business-services/SKILL.md
@@ -253,7 +253,7 @@ reads the lines and assembles the sub-batch itself.
 
 The Record Map's `<Map>.Record` class **and** the `GetObject`/`PutObject`/`GetRecord`/`PutRecord` method bodies are written by the **wizard / generator into the source**, exactly like a generated SOAP client. A normal `iris_compile` (or `iris_doc put` with `compile=true`) of a Record Map class that contains only the XData block compiles green but produces **no working `GetObject`** — at runtime the FileService dies with `<METHOD DOES NOT EXIST>GetObject ... ^EnsLib.RecordMap.Service.Base.1`.
 
-When the Portal wizard is not available (MCP / headless), generate via the official API **wrapped in a `[SqlProc]`** (because `iris_execute`'s objectgenerator mode silently no-ops class-generating calls — see the friction log):
+When the Portal wizard is not available (MCP / headless), generate via the official API **wrapped in a `[SqlProc]`** (because `iris_execute`'s objectgenerator mode silently no-ops class-generating calls — verified on IRIS 2026.1):
 
 ```objectscript
 ClassMethod GenerateRecordMap(pRM As %String) As %String [ SqlProc ]
@@ -337,7 +337,7 @@ Method Preauth(pInput As %Stream.Object, Output pOutput As %Stream.Object) As %S
 }
 ```
 
-Five non-obvious rules (each cost a debug cycle — see friction log):
+Five non-obvious rules (each cost a debug cycle):
 - **Write to the `pOutput` the framework passes in — do NOT `Set pOutput = ##class(%GlobalBinaryStream).%New()`.** Rebinding the local variable orphans the framework's response stream; the HTTP reply comes back `200` with an **empty body**.
 - **The route handler runs as an INSTANCE method of the service host** (`EnsLib.REST.Service` dispatches no-class-prefix routes via `$method($this,...)`), so `..SendRequestSync(target, req, .resp)` to a BP/BO works directly inside it.
 - **`%DynamicObject` keys with underscores need `%Get`/`%Set`** — `tJSON.codigo_acto` parses as `tJSON.codigo _ acto` (the `_` is the concat operator) and breaks compilation. Use `tJSON.%Get("codigo_acto")`.
@@ -416,7 +416,7 @@ Method OnPreWebMethod() As %Status
 }
 ```
 
-This requires `EnsLib.SOAP.InboundAdapter` (an adapter that strips Authorization headers would defeat the pattern). For non-SOAP REST inbound, use the CSP web app's `AutheEnabled` bitmask (covered above) and let the gateway handle Basic — OnPreWebMethod is specific to SOAP service classes.
+This requires `EnsLib.SOAP.InboundAdapter` (an adapter that strips Authorization headers would defeat the pattern). For non-SOAP REST inbound, use the CSP web app's `AutheEnabled` bitmask (see §CSP/Web-app permissions below) and let the gateway handle Basic — OnPreWebMethod is specific to SOAP service classes.
 
 ## REST/CSP entry point: Business Service **without an adapter**
 
@@ -479,10 +479,8 @@ these IRIS-SQL specifics in mind:
 - **Discover, don't guess.** Before querying, use `iris_table_info` (or `docs_introspect`, or the
   `introspect-dont-guess` agent) to get the real table/column names rather than guessing
   system-catalog tables — and on `SQLCODE -30 Table not found`, the next call is introspection,
-  never a differently-guessed name. Collection properties on a RecordMap `.Record` or message
-  class project to a child table **in the parent's schema** (`COCINA.MSG.MenuRecibido` +
-  `Alergias` → `COCINA_MSG.MenuRecibido_Alergias`, not `COCINA.MenuRecibido_Alergias`) — see
-  `messages` (Collections).
+  never a differently-guessed name. Collection properties project to a child table **in the
+  parent's schema** — projection rule and example: `messages` §Collections.
 
 ## See also
 

--- a/skills/dicom/SKILL.md
+++ b/skills/dicom/SKILL.md
@@ -127,7 +127,7 @@ the JDBC driver/ELS prerequisites. Reference: `iris/src/DICOM/BP/WorkListProcess
 
 > **Note** — the vendored sample wires `EnsLib.JavaGateway.Service` as the JDBC
 > bridge. In IRIS 2026.1 this class is deprecated in favour of an External
-> Language Server (see `business-operations` friction #63). New
+> Language Server (see `business-operations` §"Java Gateway BO"). New
 > work should configure the ELS `%JDBC Server` and reference it via the BO
 > setting `JGService` instead of adding a JavaGateway production item.
 
@@ -189,8 +189,8 @@ Respond `HTTP 202 Accepted` (async forwarding). Reference:
 
 The web app for the REST endpoint must be registered separately (CSP web
 application + dispatch class). See `business-services` for the
-`/csp/<app>/` registration and `AutheEnabled` bitmask (friction #84 documents
-the 96/97 values that actually work in 2026.1).
+`/csp/<app>/` registration and the `AutheEnabled` bitmask (96/97 values
+verified on 2026.1).
 
 ## Pattern 5 — DICOM ↔ HL7 / FHIR gateway
 
@@ -264,10 +264,8 @@ to `security` for cert chain validation patterns.
 
 ## Common pitfalls
 
-- **AE Title mismatch** — #1 first-day failure. `LocalAET` and `RemoteAET` on
-  Service/Operation must match the peer's expectations; the pair must be
-  registered via `AssociationContext.AETExists` + `CreateAssociation` in
-  `OnStart` before any traffic flows.
+- **AE Title mismatch** — #1 first-day failure; register the pair in `OnStart`
+  and verify with `TraceVerbosity=2` — see §"AE Title configuration" above.
 - **Transfer syntax negotiation** — sender offers JPEG-lossless, IRIS only
   registered `IMPLICITVRLETRANSFERSYNTAX`. Association is rejected. List every
   syntax you intend to support in the `$lb(...)` passed to `CreateAssociation`.

--- a/skills/hl7-schemas/SKILL.md
+++ b/skills/hl7-schemas/SKILL.md
@@ -73,7 +73,7 @@ Use case: receiving ADT_A01 messages that include a custom `ZPI` segment carryin
 
 ## Cookbook — MCP-friendly import via XML + SqlProc
 
-Closes friction-log #106. When the Portal UI isn't available (working entirely via MCP, headless CI, scripted environment refresh), the canonical path is:
+When the Portal UI isn't available (working entirely via MCP, headless CI, scripted environment refresh), the canonical path is:
 
 1. Author the schema as a **standalone XML file** (root `<Category>`, see format below).
 2. Call `##class(EnsLib.HL7.SchemaXML).Import(file, .pCategoryImported)` from a SqlProc wrapper.

--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -194,9 +194,9 @@ Worked example: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch05_bpl_dtl/xml-p
 - **Putting business properties on the carrier instead of the payload** in SOAP scenarios → wizard regeneration overwrites them.
 - **Missing pair**: Request without matching Response when the operation is synchronous and the BP expects a typed response.
 - **Forgetting indexes** on properties used by `message-search-debug` — message search is fast only on indexed properties.
-- **An object property typed `%Persistent` "to be safe", with no delete cascade** → the child rows survive every purge. No error, nothing in the Event Log, the table just grows forever. Either make it `%SerialObject` (the default for a value object) or add the trigger — see **Complex properties**.
-- **Recursive properties on a `%SerialObject`** — a class that contains itself (CDA's nested sections are the classic case) → cyclic-reference compile error; switch to `%Persistent` and add the delete cascade.
-- **Adding `SourceFilename` / `SourceLine` to a message that comes from a Record Mapper Record** for CSV-line forensics → Record Mapper doesn't fill those properties at runtime, even if you declare them. If you need this correlation, propagate from the BS adapter (e.g. `Ens.MessageHeader` carries `%Source` / `%FileName` from the file adapter) instead of adding properties that stay empty.
+- **An object property typed `%Persistent` "to be safe", with no delete cascade** → child rows survive every purge and the table grows forever, silently. See §**Complex properties** for the `%SerialObject`-vs-trigger fix.
+- **Recursive properties on a `%SerialObject`** → cyclic-reference compile error. See §**Complex properties** (row 4) and the CDA section.
+- **Adding `SourceFilename` / `SourceLine` to a Record Mapper message** → the mapper never fills them; propagate provenance from the BS adapter instead — see `business-services`.
 
 ## Testing / how to verify
 

--- a/skills/production-lifecycle/SKILL.md
+++ b/skills/production-lifecycle/SKILL.md
@@ -442,18 +442,18 @@ If the installer must run identically on Linux and Windows, prefer driving it fr
 
 - **Editing settings in the production XML directly** in TEST/PROD instead of using Default Site Settings → values get blown away on next deploy.
 - **Stop/Start when Update would do** → unnecessary downtime.
-- **Restart-then-act without waiting for Running** → `StartProduction` returns before the production is up; the next call sees a Stopped production and fails downstream. Poll `Ens.Director.IsProductionRunning()` after every restart (see the RestartProduction pattern above).
-- **Re-issuing an identical `start` after a refusal** → `ErrProductionSuspendedMismatch` / `ErrProductionNotShutdownCleanly` / `ErrInvalidProduction` never clear on retry; the state must change first. Status first, then the recovery ladder (see "When the production will NOT start").
-- **Probing credentials with `IDKeyExists()`** → the method does not exist on `Ens.Config.Credentials`; runtime `<METHOD DOES NOT EXIST>`. Use `%OpenId()` + `$IsObject()`.
+- **Restart-then-act without waiting for Running** → poll `Ens.Director.IsProductionRunning()` after every restart — see §"Hot-swap vs. restart" above.
+- **Re-issuing an identical `start` after a refusal** → the refusal never clears on retry; the state must change first. See §"When the production will NOT start — the recovery ladder".
+- **Probing credentials with `IDKeyExists()`** → the method does not exist; use `%OpenId()` + `$IsObject()` — see §"Probing for an existing credential" above.
 - **Ignoring the rollback file** after a botched import → manual recovery is much harder.
 - **Items disabled in DEV that get re-enabled by import** because the export captured them as `Enabled=true`.
 - **Auditing `PoolSize=1` as a defect** → it's the correct default everywhere. Raise only with measured evidence.
 - **Production XML edited by two people simultaneously** → merge conflicts in XML; coordinate via source control.
 - **Forgetting custom utility classes** in the export bundle → import succeeds, runtime breaks.
-- **Using `EnsLib.JavaGateway.Service` as a production item for JDBC** → deprecated in IRIS 2026.1 (the class itself flags "use an External Language Server instead"). Reference the ELS by name from the BO's `JGService` setting; the gateway item, if kept, should point its `%gatewayName` at the ELS (`%JDBC Server` or your custom one).
+- **Using `EnsLib.JavaGateway.Service` as a production item for JDBC** → deprecated in IRIS 2026.1; reference the ELS from the BO's `JGService` setting — see §"Default scaffolds" above.
 - **Item name that breaks `Tipo.Nombre`** (`Java.Gateway`, `Censo`, `myBS`) → rename to fit the pattern (`Util.JavaGateway`, `BS.Censo`). Cosmetic but it affects portal grouping and search.
-- **Missing `Ens.Alerts` router** → exceptions die in the Event Log with no fan-out. Always include the alert router + at least a file sink in the scaffold.
-- **No purge task scheduled** → `Ens.MessageHeader` and custom-message tables grow forever. Add `Ens.Util.Tasks.Purge` at production creation time and audit existing productions for its absence.
+- **Missing `Ens.Alerts` router** → exceptions die in the Event Log with no fan-out — scaffold rule in §"Default scaffolds" above.
+- **No purge task scheduled** → message tables grow forever; add `Ens.Util.Tasks.Purge` at creation time — see §"Default scaffolds" above.
 - **Adding `Schedule=""` and `LogTraceEvents="false"` to every item** → those are defaults; setting them explicitly to the default value adds noise to the XML and to diffs. Leave them off.
 
 ## Testing / how to verify

--- a/skills/soap-bo/SKILL.md
+++ b/skills/soap-bo/SKILL.md
@@ -231,7 +231,7 @@ classes + native credential/SSL settings. Use HTTP-manual for: unreachable-at-bu
 the stack chokes on, or any case where `%SOAP.WebClient` gives `<ZSOAP> 64` and you can't tell why. **Do not**
 fall back to hand-injecting an `Authorization: Basic` header by reaching into `..Adapter.%CredentialsObj` —
 that's the anti-pattern this section exists to prevent; either generate the client (native `Credentials`) or
-set the adapter's `Credentials`/`SSLConfig` settings. Document the choice as a friction-log entry.
+set the adapter's `Credentials`/`SSLConfig` settings. Document the choice in the project's decision log.
 
 ### HTTP-manual client details that each cost a debug cycle
 

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -39,12 +39,10 @@ ERROR #5001: Parameter PRODUCTION must be specified
 
 Two consequences that are easy to get wrong (verified on IRIS 2026.1):
 
-- **A class that hit `#5001` never compiled, so to the test runner it does not exist.** If you
-  miss the compile error, the *next* thing you see is `iris_test` answering `NO_TESTS_FOUND` —
-  which is a **correct answer about a class that was never created**, not a discovery or naming
-  problem. `%Dictionary.CompiledClass` can still list the class name, which is exactly why this
-  masquerades as a discovery bug. Never diagnose `NO_TESTS_FOUND` without re-reading the last
-  compile result first.
+- **A class that hit `#5001` never compiled, so to the test runner it does not exist** — a later
+  `NO_TESTS_FOUND` is a correct answer about a missing class, not a discovery bug. Measured across
+  an eval campaign, this single omission accounted for **every** zero-tests-run failure. Diagnosis
+  path: the `NO_TESTS_FOUND` recovery recipe below.
 - The value must be **non-empty**, but it need not name an *existing* production to compile —
   existence is asserted at runtime when the lifecycle starts the production. Name the real
   production anyway; a wrong name just moves the failure to run time.
@@ -155,7 +153,7 @@ against an implementation that silently drops every field.
 
 ## Where to store the tests
 
-`MyApp.Tests.*` package, compiled in the namespace alongside `MyApp.*`. Source-controlled in Git (VS Code ObjectScript export or `$system.OBJ.Export`). With `%UnitTest.TestProduction.Run()` you don't need `/noload` gymnastics — invoke directly by class name. You **do** still need `^UnitTestRoot` pointing at an existing server-side directory: the manager's "Finding directories" step runs regardless, and an invalid path yields a **silent zero-test run** (see `unit-tests`). The MCP's `iris_test` sets `^UnitTestRoot` itself; the trap bites direct `Run()` / `DebugRunTestCase` invocations.
+`MyApp.Tests.*` package, compiled in the namespace alongside `MyApp.*`. Source-controlled in Git (VS Code ObjectScript export or `$system.OBJ.Export`). With `%UnitTest.TestProduction.Run()` you don't need `/noload` gymnastics — invoke directly by class name. You **do** still need `^UnitTestRoot` → an existing server-side directory (silent zero-test run otherwise — see the `Run()` bullet above and `unit-tests`).
 
 ## Canonical skeletons (USE THESE AS TEMPLATES)
 
@@ -332,7 +330,7 @@ Effect:
 - Programmatic: `..SendRequest(...)` and `EnsLib.Testing.Service.SendTestRequest(...)` both work when the production is running with this flag.
 - Internally: a hidden `EnsLib.Testing.Process` is registered and dispatches the wrapped `EnsLib.Testing.Request` to the target via `SendRequestAsync`.
 
-**Important — security**: `TestingEnabled="true"` is a development setting. **Never deploy a production to prod with this flag on** — anyone with the Testing resource can fabricate messages into running BPs/BOs. Strip it (or guard via a deployment-time setting) before promoting.
+**Important — security**: `TestingEnabled="true"` is a development setting — the **correct default** in dev/workshop productions, and a risk only where deploy-to-prod automation exists. **Never deploy a production to prod with this flag on** — anyone with the Testing resource can fabricate messages into running BPs/BOs. Strip it (or guard via a deployment-time setting) before promoting.
 
 ## Running the tests
 
@@ -404,15 +402,15 @@ See `business-operations` and `bpl` for the runtime side of the same rule.
 
 ## Pitfalls specific to Interop TDD
 
-- **Extending `%UnitTest.TestCase` instead of `%UnitTest.TestProduction`** — you lose `Run()`, `SendRequest`, `GetEventLog`, etc., and end up reinventing them with `$$$EnsRuntimeAppData` polling and embedded SQL. Don't.
-- **Omitting `Parameter PRODUCTION` (or leaving it `= ""`)** — the class fails to compile with `#5001`, and everything downstream (`iris_test` → `NO_TESTS_FOUND`, empty `^UnitTest.Result`) is a correct report about a class that doesn't exist. Measured across an eval campaign, this single omission accounted for **every** zero-tests-run failure while the class *looked* complete. Non-empty is the compile-time requirement; naming the real production is the runtime one.
+- **Extending `%UnitTest.TestCase` instead of `%UnitTest.TestProduction`** — you lose everything the superclass provides and reinvent it by hand. See §"Baseline class" above.
+- **Omitting `Parameter PRODUCTION` (or leaving it `= ""`)** — `#5001` at compile time; the class never exists to any runner. See §"Required parameters" above.
 - **Stubbing the adapter in BO tests.** In conventional software you'd unit-test the BO method with a mocked adapter — in IRIS Interop that's an anti-pattern. The adapter boundary is exactly where the defects you care about live (auth, classpath, type marshalling, encoding, timeouts). Stubs make the test green while the real thing breaks. Use a real adapter against a real test endpoint.
 - **Forgetting to override `TestControl()`** — TestProduction will start/stop your production every time you `Run()`. Override to no-op when the production is managed externally.
 - **Forgetting to seed `..BaseLogId`** — `GetEventLog` returns nothing if `BaseLogId` is empty. Seed it in `OnBeforeAllTests` from `MAX(ID) FROM Ens_Util.Log`.
 - **Asserting on internal state** instead of public contract. Assert on what the next consumer (DTL, BO, downstream system) actually sees.
 - **No fixture strategy** — paste-in literals everywhere. Centralize sample inputs in a fixtures class (`MyApp.Tests.Fixtures.Censo`).
 - **File fixtures on a path only the agent can see.** A test that reads sample data from a file (`CopyFile`, an HL7 drop, a CSV) runs **inside IRIS** — and when IRIS is in a container, your working directory does not exist there. The red assert says "file not found" against a path that plainly exists on *your* side, and the fix is never to retry the path. Put server-read fixtures on a **server-visible path**: the container's mounted data directory, or ferry the content in via the MCP (`iris_execute` writing a temp file server-side, or inline the fixture as a string in the test class — the most portable option).
-- **`TestingEnabled="true"` left in a deployed production** — security/integrity risk. Treat it like a debug flag. (Note: `TestingEnabled="true"` is the **correct default** in dev/workshop productions — only flagged here for environments with deploy-to-prod automation.)
+- **`TestingEnabled="true"` left in a deployed production** — treat it like a debug flag. See §"Enabling the Testing Service" (security note).
 - **Asserting only on `$$$LOGINFO` presence in the event log** ("INSERT OK paciente_id=...") instead of on the row's actual contents → the log proves the BO method ran, not that the destination has the right values. Add at least one assert that reads the side-effect back: a `SELECT` via psql/`Adapter` in `OnAfterAllTests`, or a small **verifier BO** callable via `..SendRequest(verifier, query, .resp, 1)` that returns the row for property-by-property asserts. The log is necessary but insufficient.
 - **Test methods without a description comment** — When a test fails, the first thing the user sees is the method name in the portal. A `///` comment on the method clarifies *what spec clause* the test verifies, not just *what code it exercises*. One line is enough: `/// Verifies that empty Alergias is marshalled to SQL NULL`.
 

--- a/skills/transformations/SKILL.md
+++ b/skills/transformations/SKILL.md
@@ -173,10 +173,10 @@ Keep the validation predicates in a reusable `App.UTL.FunctionSet Extends Ens.Ut
 - **Defaulting to Create=New** when source and target shapes match → costly rebuilding of every segment.
 - **Forgetting to compile before testing** → the editor lies (runs the previous compiled version).
 - **Lookup() without a default parameter** → silent "" on miss, hard to debug.
-- **Validation lists / `In()` checks that don't tolerate diacritic and case variants** → `"Diabetica"` ≠ `"Diabética"` ≠ `"diabética"`. Spanish-language input drifts on tildes and casing constantly; a hardcoded literal list rejects legitimate input silently. Normalize **both sides** with `$ZCONVERT(...,"L")_$ZSTRIP(...,"*-CWE")` (see the `NormalizeKey` example in the FunctionSet section above) and compare normalized values, or accept every variant explicitly in the list. Same rule for lookup table keys — store the normalized form.
+- **Validation lists / `In()` checks that don't tolerate diacritic and case variants** → `"Diabetica"` ≠ `"Diabética"` ≠ `"diabética"`; a hardcoded literal list rejects legitimate input silently. Normalize **both sides** before comparing — see `NormalizeKey` in the FunctionSet section above; normalized lookup-table keys: `lookup-tables`.
 - **Switch cases ordered generic-to-specific** → generic case matches first, specific cases never run.
 - **Foreach over the wrong group** in HL7 nested structures (e.g. iterating PIDgrp when you wanted PIDgrpgrp).
-- **Bounding a repeating-segment loop with `AL1Count`** → returns `""` on schema versions that don't expose it; `For i=1:1:""` runs zero times and the transform "succeeds" having processed nothing. Bounded loop + `Quit:'$IsObject(seg)` instead (see the iteration section below).
+- **Bounding a repeating-segment loop with `AL1Count`** → returns `""` on schemas that don't expose it; the loop runs zero times and the transform "succeeds" having processed nothing. See §"Iterating repeating segments" below for the safe pattern.
 - **DTL doing DB lookups in `code` actions** that block the BP — move to a method that can be cached.
 - **CDA in DTL** — almost always wrong; switch to XSLT.
 - **Hand-rolling date conversion in `<code>` blocks** (`$ZDATEH(source.X, 4, , , , , , , -1)` etc.) → prefer `ConvertDateTime` from the function picker, or wrap the logic in a project FunctionSet subclass (see above). Inline `$ZDATEH` with positional empty args is unreadable and not reusable.
@@ -299,7 +299,7 @@ For i = 1:1:source.SegCount {
 
 - **`%Date` (storage = integer day count) ≠ string `YYYY-MM-DD`**. The PostgreSQL JDBC driver throws `StringIndexOutOfBoundsException: begin 0, end 10, length 5` when bound a raw `%Date` integer to a `DATE` column. Convert in the DTL or BO with `$ZDATE(tDate, 3)` before binding.
 - **`%TimeStamp` for `xs:dateTime`**: replace the space with `T`. `$TRANSLATE($ZDATETIME($HOROLOG, 3), " ", "T")` produces `2026-05-13T07:13:59`.
-- **Canonical message types should hold values as `%String`** when they collect from HL7/REST sources. Typing `Planta As %SmallInt` and then receiving `"PLANTA3"` from `PV1:3.1` produces `ERROR #7207: Datatype value 'PLANTA3' is not a valid number` and kills the BP. If you need numeric, cast in the DTL after extraction.
+- **Canonical message types should hold values as `%String`** when they collect from HL7/REST sources — a typed field receiving free text (`Planta As %SmallInt` ← `"PLANTA3"`) dies with `#7207` and kills the BP; cast in the DTL after extraction. Full datatype rule: `messages`.
 
 ## Lab device integration — DT in BOTH directions
 

--- a/skills/unit-tests/SKILL.md
+++ b/skills/unit-tests/SKILL.md
@@ -8,7 +8,7 @@ description: %UnitTest framework - runner, storage, results. Routed from interop
 > **Workflow note**: for the *order of work* (spec → test → red → implement → green → refactor) and for **the baseline class you must extend** (`%UnitTest.TestProduction`, not `%UnitTest.TestCase`), see **`tdd`**. That's the entry point when you're starting a new Interop component. This skill is the lower-level reference for **how the framework itself works**: where tests live on disk, how to invoke runners, where results land, how to inspect them.
 
 IRIS ships a built-in unit-test framework with two relevant classes:
-- **`%UnitTest.TestProduction`** — the Interop-flavoured superclass. **Use this for any Interop test.** Provides `Run()`, `SendRequest`, `GetEventLog`, `ChangeSetting`, `CreateCredentials`, file helpers, auto-properties (`BaseLogId`, `HL7InputDir`, etc.). Detail in `tdd`. **Its `PRODUCTION` parameter is compile-time mandatory**: a method generator fails the compile of any subclass with a missing or empty value (`ERROR #5001: Parameter PRODUCTION must be specified`) — after which every runner correctly reports zero tests, because the class never compiled.
+- **`%UnitTest.TestProduction`** — the Interop-flavoured superclass. **Use this for any Interop test.** Provides `Run()`, `SendRequest`, `GetEventLog`, `ChangeSetting`, `CreateCredentials`, file helpers, auto-properties (`BaseLogId`, `HL7InputDir`, etc.). Detail in `tdd`. **Its `PRODUCTION` parameter is compile-time mandatory** (`#5001` otherwise — see `tdd` §"Required parameters" and the pitfall below).
 - **`%UnitTest.TestCase`** — the generic base. **Only use directly for tests of pure utility code that has nothing to do with Interop** (and even then, extending TestProduction is fine if the namespace is Interop-enabled).
 
 ## When to use this skill
@@ -25,14 +25,14 @@ Two patterns:
 
 1. **In-namespace package** (recommended). Create `MyApp.Tests.*`, compile the classes once via your normal source-control flow (VS Code ObjectScript export, `iris_compile`, etc.). Run with `RunTest("MyApp.Tests", "/noload/nodelete")`. The runner walks the namespace, finds compiled tests, runs them in place.
 
-2. **Use `TestProduction.Run()` / `Debug()`** (the canonical Interop path). The inherited methods invoke a single test class by name with `/noload/nodelete` semantics — they don't load test source from disk or delete classes after the run. **But they do still call the manager's "Finding directories" step**, so `^UnitTestRoot` must point at an existing directory (see below).
+2. **Use `TestProduction.Run()` / `Debug()`** (the canonical Interop path). The inherited methods invoke a single test class by name with `/noload/nodelete` semantics — they don't load test source from disk or delete classes after the run (`^UnitTestRoot` caveat below).
 
    ```objectscript
    do ##class(MyApp.Tests.DT.X).Run()      ; same-process, prints to terminal
    do ##class(MyApp.Tests.DT.X).Debug()    ; same-process, stops on failure for inspection
    ```
 
-   **`Run()` still requires `^UnitTestRoot` to point at an existing directory** — even though we're not loading from it, the manager calls "Finding directories" early and fails with `ERROR #5007` if the path is invalid. **The failure does not look like a path problem**: the `#5007` is only in the run's log output, and the manager still records a result — with **zero test cases**. Anything that reads only the recorded result (a harness, a wrapper, `^UnitTest.Result`) sees "run completed, no tests found", indistinguishable from a discovery or naming issue. (The MCP's `iris_test` sets `^UnitTestRoot` itself before running — this trap bites direct `Run()` / `DebugRunTestCase` invocations via `iris_execute`, the terminal, or external harnesses.) Workaround:
+   **`Run()` still requires `^UnitTestRoot` to point at an existing directory** — nothing is loaded from it, but the manager's "Finding directories" step runs first and fails with `ERROR #5007` if the path is invalid. **The failure does not look like a path problem**: the `#5007` is only in the run's log output, and the manager still records a result — with **zero test cases**. Anything that reads only the recorded result (a harness, a wrapper, `^UnitTest.Result`) sees "run completed, no tests found", indistinguishable from a discovery or naming issue. (The MCP's `iris_test` sets `^UnitTestRoot` itself before running — this trap bites direct `Run()` / `DebugRunTestCase` invocations via `iris_execute`, the terminal, or external harnesses.) Workaround:
 
    ```objectscript
    set ^UnitTestRoot = "C:\Temp\unittest_fake"
@@ -219,14 +219,8 @@ Method TestHappyPath()
     Do $$$AssertEquals(tTarget.GetValueAt("PV1:3"), "ICU", "PV1:3 should be Department")
 }
 
-Method TestEmptyDepartment()
-{
-    Set tSrc = ##class(MyApp.Msg.PatientCensusRequest).%New()
-    Set tSrc.PatientId = "P12345"
-    Set tSC = ##class(MyApp.DT.PatientCensusToADT).Transform(tSrc, .tTarget)
-    Do $$$AssertStatusOK(tSC)
-    Do $$$AssertEquals(tTarget.GetValueAt("PV1:3"), "", "Empty department should map to empty PV1:3")
-}
+/// Add one rejection/boundary Test* method per spec clause — never ship happy-path-only.
+/// Completeness checklist and full skeletons (DTL, routing rule, BO, BPL): see `tdd`.
 }
 ```
 
@@ -235,7 +229,7 @@ For Interop-specific test skeletons (DTL / routing rule / BO method / BPL), see 
 ## Common pitfalls
 
 - **Tests stored where the runner deletes them after run** — pick a storage pattern that doesn't get cleaned up (see "Where to store" above).
-- **`Run()` failing with `ERROR #5007: Finding directories`** — `^UnitTestRoot` not set or points at a non-existent path (server-side!). Set it to any existing directory; runner reads no files from it. Remember the symptom is usually **not** the `#5007` itself but a run that "completes" with zero test cases — check `^UnitTestRoot` before chasing discovery hypotheses.
+- **Zero test cases from `Run()` (or `ERROR #5007: Finding directories`)** — `^UnitTestRoot` unset or invalid. The symptom is usually the silent zero-test run, not a visible `#5007` — check `^UnitTestRoot` before chasing discovery hypotheses; workaround in §"Where to store tests".
 - **`#5001: Parameter PRODUCTION must be specified` at compile time** — every `%UnitTest.TestProduction` subclass must declare a **non-empty** `Parameter PRODUCTION` (a method generator enforces it; verified on IRIS 2026.1). The value need not name an existing production *to compile* — existence is asserted at runtime when the lifecycle starts the production. A class that hit this error never compiled, so a later `NO_TESTS_FOUND` is the correct answer about a missing class, not a discovery bug — re-read the compile output before touching anything else.
 - **Qualifier syntax `/noload=0`** → `#5001: can not mix negated form with value`. Boolean qualifiers are presence-only.
 - **`Quit <value>` inside `Try`** → `#1043`. Set tSC; exit Try; quit after.


### PR DESCRIPTION
## Summary

Second PR of the approved **compact-in-place** refactor (follows #42). Within each skill, a rule now appears at most twice: its full statement in the owning section, plus a TL;DR/pitfall line that *points* at that section instead of restating the mechanism. One commit per skill so any single change can be dropped in review.

- **tdd**: `Parameter PRODUCTION` drops from 6 statements to owning-section (full, eval measurement absorbed) + recipe step + TL;DR; TestCase/TestingEnabled/`^UnitTestRoot` restatements become pointers. All 4 skeletons untouched (copy-paste-critical per issues #38/#39).
- **unit-tests**: duplicate `^UnitTestRoot` paragraphs merged; intro `PRODUCTION` parenthetical compressed (the pitfall keeps the full statement); the canonical DTL pattern keeps the fully-asserted happy path and replaces its second method with an explicit "one rejection/boundary method per spec clause" instruction deferring to tdd's checklist.
- **business-operations**: timeout precedence and ReplyCodeActions keep their complete rules + both literal action strings, deferring mechanism/decision-matrix to `bpl`/`alerting` (owners); SQL-guess pitfall points at the introspection section; stale pre-rename skill id `iris-interop-transformations` fixed.
- **transformations / messages / dicom / production-lifecycle / alerting**: pitfalls keep symptom + remedy and point at their owning sections instead of re-teaching.
- **Correctness fixes swept up**: business-services `AutheEnabled` "covered above" actually pointed *below*; all 6 dead "friction log/#NN" references (a log not shipped in this repo) replaced with skill pointers or removed (business-services, dicom, hl7-schemas, soap-bo).

## Deliberately NOT touched (looks repetitive, is load-bearing)

Skeleton preambles ×6 across 3 skills (`#5001` compile-critical); the `OnBeforeAllTests` bodies ×4 in tdd (a comment placeholder would still compile but silently break `GetEventLog` — the exact silent-failure class the eval history documents); tdd's happy+rejection DTL pair; both `Util.JDBCGateway` XML items; the per-BO settings checklist table.

## Verification (all green)

Skeleton integrity unchanged: `Parameter PRODUCTION = ` ×5 in tdd, `SELECT NVL(MAX(ID),0)` ×4, `TestControl()` counts 5/1/1 (tdd/unit-tests/lookup-tables). Ownership: `#DIM errObj` only in unit-tests; `:?R=RF` exactly once in alerting and business-operations. Zero `friction` refs and zero stale skill ids remain; every `${CLAUDE_PLUGIN_ROOT}/BestPractices/…` path resolves. Corpus: 5,435 → 5,381 lines / 48,794 → 48,344 words (with #42: −54 lines / −450 words net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)