### PR TITLE
release: 1.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.6.1"
+    "version": "1.6.2"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Patch release rolling up the compact-in-place refactor and one substantive correctness fix:

- **#42** — try/catch `%Status` idiom owned by `unit-tests`; `bpl`/`transformations` defer with complete one-paragraph rules; the previously-unreferenced canonical `objectscript-trycatch.cls` example is now wired into all three.
- **#43** — intra-file compaction: each rule states its mechanism once in its owning section, pitfalls/TL;DRs point instead of restating; dead friction-log references and stale pre-rename skill ids removed; `business-services` `AutheEnabled` direction fix. Skeletons and load-bearing rules untouched.
- **#44** — alert router magic name corrected to **`Ens.Alert`** (singular) across six skills including conformance-review CR-9; verified against live IRIS 2026.1 framework source.

Corpus: 5,435 → 5,381 lines / 48,794 → 48,334 words. Version 1.6.1 → 1.6.2 in plugin.json + marketplace.json; skill/agent/hook counts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)