### PR TITLE
docs(unit-tests): %UnitTest assertion-macro inventory (issue #47)

### DIFF
--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -142,6 +142,10 @@ Anti-pattern worth naming: a `Test*` method whose only assertion is `$$$AssertSt
 asserts the component did not error. It does not assert it did the right thing, and it passes
 against an implementation that silently drops every field.
 
+Write assertions only with macros that exist — there is no `$$$AssertNotNull` or `$$$AssertGreater`,
+and inventing one fails the compile with `MPP5610`. Mechanism: see `unit-tests` (section "Assertion
+macros — the inventory").
+
 ## What's testable in IRIS Interop — decision table
 
 | Component | Test approach |
@@ -408,7 +412,7 @@ See `business-operations` and `bpl` for the runtime side of the same rule.
 
 ## Pitfalls specific to Interop TDD
 
-- **Extending `%UnitTest.TestCase` instead of `%UnitTest.TestProduction`** — you lose everything the superclass provides and reinvent it by hand. See §"Baseline class" above.
+- **Extending `%UnitTest.TestCase` instead of `%UnitTest.TestProduction`** — you lose everything the superclass provides and reinvent it by hand. Nor is `%UnitTest.TestCase` an escape hatch for a compile error: `Extends %UnitTest.TestProduction` and `Parameter PRODUCTION` are fixed points — fix the error, never remove the parameter or change the superclass to silence it. See §"Baseline class" above.
 - **Omitting `Parameter PRODUCTION` (or leaving it `= ""`)** — `#5001` at compile time; the class never exists to any runner. See §"Required parameters" above.
 - **Stubbing the adapter in BO tests.** In conventional software you'd unit-test the BO method with a mocked adapter — in IRIS Interop that's an anti-pattern. The adapter boundary is exactly where the defects you care about live (auth, classpath, type marshalling, encoding, timeouts). Stubs make the test green while the real thing breaks. Use a real adapter against a real test endpoint.
 - **Forgetting to override `TestControl()`** — TestProduction will start/stop your production every time you `Run()`. Override to no-op when the production is managed externally.

--- a/skills/unit-tests/SKILL.md
+++ b/skills/unit-tests/SKILL.md
@@ -175,6 +175,15 @@ The SqlProc wrapper above traverses this global to compute the pass/fail summary
 **method node's** own flag, not its assert children, for the reason given in that section. The portal
 renders the same data graphically.
 
+## Assertion macros — the inventory
+
+The assertion macros are already in scope in any `%UnitTest.TestCase` subclass (`TestProduction` included) — **no `Include` line needed**. Verified on IRIS 2026.1:
+
+- **These exist**: `$$$AssertEquals`, `$$$AssertNotEquals`, `$$$AssertTrue`, `$$$AssertNotTrue`, `$$$AssertStatusOK`, `$$$AssertStatusNotOK`, `$$$LogMessage`.
+- **These do NOT exist**: `$$$AssertNotNull`, `$$$AssertNotEmpty`, `$$$AssertGreater`. Inventing one fails the compile with `MPP5610 : Referenced macro not defined`. Compose from the real set instead: `$$$AssertTrue(val'="", ...)`, `$$$AssertTrue(x>y, ...)`.
+- Do **not** add `Include %UnitTest` as a recovery for `MPP5610` — it fails again with `MPP5635 : No include file '%UnitTest'` and points the fix at the wrong problem. The macro name itself is wrong; replace it.
+- Ens logging macros (in the BS/BP/BO code the tests exercise) are **UPPERCASE**: `$$$LOGINFO`, `$$$LOGERROR`, `$$$LOGWARNING`. `$$$LogError` is a different, nonexistent macro — casing matters, and the mixed-case slip produces the same `MPP5610`.
+
 ## Error handling inside test methods
 
 When a test method drops to ObjectScript that may raise, use the standard try/catch idiom:
@@ -236,6 +245,7 @@ For Interop-specific test skeletons (DTL / routing rule / BO method / BPL), see 
 - **Asserting on internal state instead of public contract** — tests get brittle. Assert on what the next consumer (DTL, BO, downstream system) will actually see.
 - **Real adapter calls in unit tests** → flaky, slow, environment-dependent. That's an integration test, not a unit test.
 - **Missing `$$$AssertStatusOK` on every `Set tSC = ...`** — silent failures pass the test.
+- **Inventing an assertion macro** (`$$$AssertNotNull`, `$$$AssertGreater`) or mis-casing an Ens logging one (`$$$LogError`) → `MPP5610`; `Include %UnitTest` is never the fix. See §"Assertion macros — the inventory".
 - **Tests that depend on each other** — each test method should be runnable in any order, in isolation.
 - **No fixture data strategy** — paste-in literals everywhere. Centralize sample messages/inputs in a fixtures class.
 - **Forgetting the portal URL in runner output** — students go straight to `^UnitTest.Result` by hand because they don't know the portal exists.


### PR DESCRIPTION
## What changed

**`skills/unit-tests/SKILL.md`** (owner of the mechanism)
- New section **"Assertion macros — the inventory"**, placed just before the error-handling material: the seven macros that exist and are already in scope in any `%UnitTest.TestCase` subclass with **no `Include` line** (`$$$AssertEquals`, `$$$AssertNotEquals`, `$$$AssertTrue`, `$$$AssertNotTrue`, `$$$AssertStatusOK`, `$$$AssertStatusNotOK`, `$$$LogMessage`); the three commonly invented ones that do not (`$$$AssertNotNull`, `$$$AssertNotEmpty`, `$$$AssertGreater` → `MPP5610 : Referenced macro not defined`) with compose-from-the-real-set alternatives; the explicit warning that `Include %UnitTest` is not a recovery (`MPP5635 : No include file '%UnitTest'`); and the UPPERCASE Ens logging macros (`$$$LOGINFO` / `$$$LOGERROR` / `$$$LOGWARNING` — `$$$LogError` is a different, nonexistent macro).
- One pointer-grade bullet added to Common pitfalls referencing that section.

**`skills/tdd/SKILL.md`** (pointer only, per the one-owner rule)
- One-sentence rule + cross-link to the inventory, placed with the assertion guidance in "How much test is enough".
- The existing pitfall forbidding `%UnitTest.TestCase` now carries the outcome rule from the issue: TestCase is not an escape hatch for a compile error — `Extends %UnitTest.TestProduction` and `Parameter PRODUCTION` are fixed points; fix the error, never remove the parameter or change the superclass to silence it.

## Why

Issue #47's measured evidence: **12 of 38 arm-H runs** (8 of 12 scenarios) invented an assertion macro and hit `MPP5610` — the most frequent single failure signature in the arm — and no skill carried an inventory. Verified live on IRIS 2026.1 by the filer: the seven listed macros compile with no `Include` line, the three invented ones each produce `MPP5610`, and the standard recovery (`Include %UnitTest`) fails with `MPP5635`, cascading in one run to dropping `Parameter PRODUCTION` and rewriting the class as `Extends %UnitTest.TestCase`.

Integrity checks pass: `Parameter PRODUCTION = ` count in tdd is 5, `SELECT NVL(MAX(ID),0)` count is 4; only the two intended files changed.

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)