### PR TITLE
docs(messages): underscore-identifier rule (#5559) and %File API traps

### DIFF
--- a/skills/business-operations/SKILL.md
+++ b/skills/business-operations/SKILL.md
@@ -92,6 +92,17 @@ If the destination is a SOAP web service, **stop and use `soap-bo`** instead. It
 | `LogTraceEvents` | Per-item toggle for `$$$TRACE` calls. Default off in prod, on in dev. `$$$LOGINFO`/`$$$LOGWARNING` are not gated by this. |
 | Stay-alive / reconnect | TCP/SOAP — controls whether the BO holds the connection open. |
 
+## File output — two `%File` API traps
+
+When creating the directory a file BO writes into (or checking its output from a test):
+
+- Use `##class(%File).CreateDirectoryChain(dir)` for any path whose parents may not exist.
+  `CreateDirectory` creates **one** level only, and on failure returns a bare `0` — not a
+  `%Status`, so there is no error text to read; a missing intermediate directory fails silently.
+- The existence tests are `##class(%File).Exists(file)` and `##class(%File).DirectoryExists(dir)`.
+  There is no `%File.FileExists` — calling it fails as `<METHOD DOES NOT EXIST>`, easy to misread
+  as a read-only filesystem when it is just a wrong method name.
+
 ## Error handling and retry policy
 
 `If $$$ISERR(tSC) Quit tSC` propagates every error the same way. That's almost never what you want — transient errors (timeout, connection drop) should retry; permanent errors (constraint violation, schema mismatch, auth failure) should suspend and alert.

--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -46,6 +46,14 @@ Storage Default { /* lives in MyApp.Msg.PatientCensusRequestD, not Ens.MessageBo
 
 Pair Request with a Response class extending `(Ens.Response, %Persistent)`. If the operation is fire-and-forget, return `Ens.Response` directly — no custom Response class needed.
 
+**Identifiers are letters and digits only — never `_`.** `_` is the concatenation operator, so
+`Property patient_id As %String;` cannot parse — and the error is actively misleading:
+`ERROR #5559: ... could not be parsed correctly, possibly due to non-matching {} or () characters`.
+The braces are fine; the name isn't. If you see #5559, check class/property/method/parameter names
+for underscores before touching a brace. Use PascalCase (`PatientId`, `ResultValue`). External JSON
+keys that do carry underscores are read via `%Get`/`%Set` on a `%DynamicObject` — see
+`business-services`.
+
 ## Complex properties — what class for an object inside a message
 
 The canonical example above is all scalars. As soon as a property is an **object** — an `Address`


### PR DESCRIPTION
Documents two live-measured IRIS facts with actively misleading errors (issue #49). Both reproduced against IRIS 2026.1; in the measured arm, `#5559` appeared in 4 of 38 runs and one agent re-pushed the same snake_case class 26 times chasing braces, while wrong `%File` calls led another to conclude the container filesystem was read-only when it was not.

**`skills/messages/SKILL.md`** — added, directly under the canonical persistent-message pattern: identifiers (class/property/method/parameter names) are letters and digits only. `_` is the concatenation operator, so `Property patient_id As %String;` fails with the misleading `ERROR #5559 "... possibly due to non-matching {} or () characters"`. States the recovery rule ("on #5559, check identifiers before touching a brace"), prescribes PascalCase, and cross-points to `business-services` for the already-covered underscore-in-`%DynamicObject`-keys case (that file is otherwise untouched, per the one-owner compaction doctrine).

**`skills/business-operations/SKILL.md`** — added a compact "File output — two `%File` API traps" section next to the adapter material (no skill owned the `%File` API): `CreateDirectoryChain` for paths whose parents may not exist, since `CreateDirectory` creates one level only and returns a bare `0` — not a `%Status`, so there is no error text to read; and the existence tests are `%File.Exists` / `%File.DirectoryExists` — there is no `%File.FileExists` (calling it fails as `<METHOD DOES NOT EXIST>`, easy to misread as a read-only filesystem).

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)