### PR TITLE
docs(messages): drop hand-written Storage block from the canonical persistent-message example

### DIFF
--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -39,10 +39,10 @@ Class MyApp.Msg.PatientCensusRequest Extends (Ens.Request, %Persistent)
 Property PatientId As %String;
 Property AdmissionDate As %TimeStamp;
 Property Department As %String(MAXLEN=80);
-
-Storage Default { /* lives in MyApp.Msg.PatientCensusRequestD, not Ens.MessageBodyD */ }
 }
 ```
+
+Do **not** write a `Storage` block. Extending `%Persistent` is what gives the message its own extent — `MyApp.Msg.PatientCensusRequestD`, not `Ens.MessageBodyD` — and IRIS generates the storage definition on first compile. Hand-writing one makes `iris_doc` refuse the write until `allow_storage_regeneration: true` is passed; the guard is protecting generated storage, so the fix is to leave the block out, not to pass the flag.
 
 Pair Request with a Response class extending `(Ens.Response, %Persistent)`. If the operation is fire-and-forget, return `Ens.Response` directly — no custom Response class needed.
 
@@ -198,6 +198,7 @@ Worked example: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch05_bpl_dtl/xml-p
 ## Common pitfalls
 
 - **Custom message without `%Persistent`** → bodies stored in `Ens.MessageBodyD`, unsearchable by property, slow to purge.
+- **Hand-written `Storage` block** → `iris_doc` refuses the write (storage guard). See §**Canonical pattern — custom persistent message**.
 - **Subclassing `EnsLib.HL7.Message`** → almost always wrong; HL7 is structurally defined by DocType, not by class hierarchy.
 - **Putting business properties on the carrier instead of the payload** in SOAP scenarios → wizard regeneration overwrites them.
 - **Missing pair**: Request without matching Response when the operation is synchronous and the BP expects a typed response.


### PR DESCRIPTION
## What changed

**skills/messages/SKILL.md** (the only file touched):

- Deleted the `Storage Default { ... }` line from the canonical persistent-message code fence (`MyApp.Msg.PatientCensusRequest`). The issue measured that **13 of 38** arm-H runs copying this template hit the MCP storage guard (`iris_doc` refusing the write until `allow_storage_regeneration: true`), costing 1-4 round trips each across 5 scenarios — pure waste on the most-copied template in the corpus.
- Kept the teaching point as prose immediately after the example: extending `%Persistent` is what gives the message its own extent (`MyApp.Msg.PatientCensusRequestD`, not `Ens.MessageBodyD`); IRIS generates the storage definition on first compile; the guard is protecting generated storage, so the fix is to leave the block out, not to pass the flag.
- Added one pointer-grade bullet in **Common pitfalls** referring back to the canonical-pattern section (full statement + one pointer, per the compaction doctrine).

Swept all other skills for the same trap (`grep -n "Storage " skills/*/SKILL.md`): no other authoring template writes a Storage block — remaining hits are conceptual prose about storage models (`soap-bo` %SerialObject-vs-%Persistent decision, `interop` message-type list, etc.) and are left alone.

Fixes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)