### PR TITLE
release: 1.6.3 - codex-parity rules, %UnitTest macro inventory, name resolution, identifier/%File facts, no hand-written Storage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.6.2"
+    "version": "1.6.3"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Bumps the plugin version to 1.6.3 in .claude-plugin/plugin.json and .claude-plugin/marketplace.json. Rolls up the five fix PRs merged to main since 1.6.2:

- PR #51 — interop owns the real-name resolution recipe (iris_symbols -> docs_introspect -> iris_table_info -> INFORMATION_SCHEMA catalog fallback, SqlTableName/SqlFieldName override trap, SQLCODE -30 rule) — fixed #48
- PR #52 — Claude-only rules relocated into skill prose: TDD definition of done, 3-attempt iteration cap, agent-vs-skill labeling — fixed #46
- PR #53 — %UnitTest assertion-macro inventory in unit-tests: the seven real macros, the invented ones (MPP5610), Include %UnitTest is not a recovery — fixed #47
- PR #54 — identifier rule in messages (letters and digits only; underscore triggers misleading ERROR #5559) and %File API traps in business-operations (CreateDirectoryChain, %File.Exists) — fixed #49
- PR #55 — hand-written Storage block dropped from the canonical persistent-message example in messages; IRIS generates storage on first compile — fixed #50

No skill/hook/agent counts changed (still 20 skills, 8 hooks, 4 agents); README untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)