### PR TITLE
docs(dicom): narrow the over-broad 'modality' trigger to imaging modality + explicit anti-trigger

### DIFF
--- a/skills/dicom/SKILL.md
+++ b/skills/dicom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dicom
-description: DICOM C-STORE/FIND/MOVE, MWL, PACS, STOW-RS. Routed from interop. Triggers: DICOM, C-STORE, C-FIND, C-MOVE, MWL, PACS, STOW-RS, DICOMweb, modality, AE Title, EnsLib.DICOM.
+description: DICOM C-STORE/FIND/MOVE, MWL, PACS, STOW-RS. Routed from interop. Triggers: DICOM, C-STORE, C-FIND, C-MOVE, MWL, modality worklist, PACS, STOW-RS, DICOMweb, imaging modality (the device), AE Title, EnsLib.DICOM. NOT a trigger: the bare word "modality" in HL7/FHIR/lab-device prose — that alone is not DICOM work.
 ---
 
 # DICOM on IRIS for Health
@@ -14,8 +14,11 @@ for every pattern here.
 
 ## When to use this skill
 
-The user mentioned DICOM, a modality, PACS, MWL, C-STORE, C-FIND, C-MOVE, STOW-RS,
-DICOMweb, AE Title, association context, or any `EnsLib.DICOM.*` class.
+The user mentioned DICOM, an imaging modality, PACS, MWL, C-STORE, C-FIND, C-MOVE,
+STOW-RS, DICOMweb, AE Title, association context, or any `EnsLib.DICOM.*` class.
+The bare word "modality" is **not** enough on its own — HL7/lab-device prose uses it
+for any bidirectional device (a lab analyzer is "a modality" in that sense); without a
+DICOM protocol cue, stay in the HL7/FHIR skills.
 
 ## Status: architecture + wiring only
 

--- a/skills/interop/SKILL.md
+++ b/skills/interop/SKILL.md
@@ -168,7 +168,7 @@ SQL-BO worked flow (child-table projections, invented system catalogs): see `bus
 | **About to build *anything* (DTL, rule, BO method, BPL) — TDD workflow** | **`iris-interop-skills:tdd`** (entry point; non-negotiable) |
 | **Built it and TDD-green — is it idiomatic / per best practices?** (run before declaring done) | **`iris-interop-skills:conformance-review`** (criteria CR-1…CR-12; the `conformance-reviewer` plugin agent — an agent, not a skill — runs it). **Mechanically: FIRST open `skills/conformance-review/SKILL.md`** — via the Skill tool where available, else read the file — before writing any review output. |
 | %UnitTest framework toolbox (storage, runner flags, ^UnitTest.Result) | `iris-interop-skills:unit-tests` (lower-level reference; the TDD skill calls into it) |
-| Anything DICOM (C-STORE, C-FIND, C-MOVE, MWL, STOW-RS, modalities, PACS) | `iris-interop-skills:dicom` (architecture + wiring patterns; defers byte-level work to docs + vendored sample at `${CLAUDE_PLUGIN_ROOT}/BestPractices/external/workshop-iris-dicom-interop/`) |
+| Anything DICOM (C-STORE, C-FIND, C-MOVE, MWL, STOW-RS, imaging modalities, PACS — the bare word "modality" for an HL7/lab device is NOT DICOM) | `iris-interop-skills:dicom` (architecture + wiring patterns; defers byte-level work to docs + vendored sample at `${CLAUDE_PLUGIN_ROOT}/BestPractices/external/workshop-iris-dicom-interop/`) |
 
 ## Exact routing — call these now (don't just describe them)
 


### PR DESCRIPTION
## What changed

Issue #57 measured `DICOM-NEG-01` (the skill must **not** fire) at **0/4 correct across two CLIs** — the only negative miss consistent across both deliveries, pointing at the trigger list rather than a delivery artifact. The issue deliberately named no term; per the filer's framing, the fix targets the term that is "common in general interop or imaging-adjacent language rather than specific to DICOM".

That term is the bare **`modality`**. The corpus itself proves the over-breadth: `business-operations/SKILL.md` uses "any modality where HL7 v2 flows in both directions" to describe a **lab analyzer** — so a prompt about a non-DICOM device can legitimately contain the word.

- **`skills/dicom/SKILL.md` frontmatter**: `modality` → `imaging modality (the device)`, added `modality worklist` (DICOM-specific, preserves recall), and an explicit anti-trigger clause: the bare word "modality" in HL7/FHIR/lab-device prose is NOT DICOM work.
- **`skills/dicom/SKILL.md` §When to use**: same narrowing plus the lab-analyzer counter-example, so the rule survives on runtimes that inject the full SKILL.md body.
- **`skills/interop/SKILL.md` router index row**: `modalities` → `imaging modalities` with the same bare-word carve-out (the router is always loaded, so its row steers firing too).

All other DICOM-specific triggers (C-STORE, C-FIND, MWL, PACS, AE Title, …) unchanged. Deep-pattern prose that says "a modality asks IRIS…" is post-load DICOM context and untouched.

Hypothesis-based per the issue's caveat ("worth a look", n small): if `DICOM-NEG-01` still fails on the next pinned pass, reopen and check the scenario prompt against the remaining vocabulary (`PACS` is the next candidate).

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)