### PR TITLE
docs(dicom): aim the anti-trigger at the observed misfire, and fix the terminology it was built on

### DIFF
--- a/skills/business-operations/SKILL.md
+++ b/skills/business-operations/SKILL.md
@@ -315,7 +315,7 @@ Worked example: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch06_adapters/java
 
 ## Lab device integration — DT in both directions
 
-When integrating with a lab analyzer / device vendor (any modality where HL7 v2 flows in both directions), even directions that look like passthrough usually need a DT. Common reasons:
+When integrating with a lab analyzer / device vendor (any instrument where HL7 v2 flows in both directions), even directions that look like passthrough usually need a DT. Common reasons:
 
 - Field truncation requirements (the receiver's parser is stricter than the sender's emitter).
 - Segment re-ordering (the receiver keys on segment position).

--- a/skills/dicom/SKILL.md
+++ b/skills/dicom/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dicom
-description: DICOM C-STORE/FIND/MOVE, MWL, PACS, STOW-RS. Routed from interop. Triggers: DICOM, C-STORE, C-FIND, C-MOVE, MWL, modality worklist, PACS, STOW-RS, DICOMweb, imaging modality (the device), AE Title, EnsLib.DICOM. NOT a trigger: the bare word "modality" in HL7/FHIR/lab-device prose — that alone is not DICOM work.
+description: DICOM C-STORE/FIND/MOVE, MWL, PACS, STOW-RS. Routed from interop. Triggers: DICOM, C-STORE, C-FIND, C-MOVE, MWL, modality worklist, PACS, STOW-RS, DICOMweb, imaging modality (the device), AE Title, EnsLib.DICOM. NOT a trigger: reading or converting .dcm files locally (e.g. a pydicom batch script) with no network protocol and no IRIS — that is file processing, not integration.
 ---
 
 # DICOM on IRIS for Health
@@ -16,9 +16,10 @@ for every pattern here.
 
 The user mentioned DICOM, an imaging modality, PACS, MWL, C-STORE, C-FIND, C-MOVE,
 STOW-RS, DICOMweb, AE Title, association context, or any `EnsLib.DICOM.*` class.
-The bare word "modality" is **not** enough on its own — HL7/lab-device prose uses it
-for any bidirectional device (a lab analyzer is "a modality" in that sense); without a
-DICOM protocol cue, stay in the HL7/FHIR skills.
+
+Not every mention of DICOM is integration work. A local batch that reads `.dcm` files
+to convert them or extract tags (pydicom, dcmtk on a laptop) has no association, no
+SCU/SCP and no IRIS — that is file processing, and this skill does not apply.
 
 ## Status: architecture + wiring only
 

--- a/skills/interop/SKILL.md
+++ b/skills/interop/SKILL.md
@@ -168,7 +168,7 @@ SQL-BO worked flow (child-table projections, invented system catalogs): see `bus
 | **About to build *anything* (DTL, rule, BO method, BPL) — TDD workflow** | **`iris-interop-skills:tdd`** (entry point; non-negotiable) |
 | **Built it and TDD-green — is it idiomatic / per best practices?** (run before declaring done) | **`iris-interop-skills:conformance-review`** (criteria CR-1…CR-12; the `conformance-reviewer` plugin agent — an agent, not a skill — runs it). **Mechanically: FIRST open `skills/conformance-review/SKILL.md`** — via the Skill tool where available, else read the file — before writing any review output. |
 | %UnitTest framework toolbox (storage, runner flags, ^UnitTest.Result) | `iris-interop-skills:unit-tests` (lower-level reference; the TDD skill calls into it) |
-| Anything DICOM (C-STORE, C-FIND, C-MOVE, MWL, STOW-RS, imaging modalities, PACS — the bare word "modality" for an HL7/lab device is NOT DICOM) | `iris-interop-skills:dicom` (architecture + wiring patterns; defers byte-level work to docs + vendored sample at `${CLAUDE_PLUGIN_ROOT}/BestPractices/external/workshop-iris-dicom-interop/`) |
+| Anything DICOM (C-STORE, C-FIND, C-MOVE, MWL, STOW-RS, imaging modalities, PACS — but NOT a local `.dcm` file batch with no network protocol and no IRIS) | `iris-interop-skills:dicom` (architecture + wiring patterns; defers byte-level work to docs + vendored sample at `${CLAUDE_PLUGIN_ROOT}/BestPractices/external/workshop-iris-dicom-interop/`) |
 
 ## Exact routing — call these now (don't just describe them)
 


### PR DESCRIPTION
## Why

Release 1.6.4 narrowed the bare word `modality` in the `dicom` triggers to fix #57.

**#57 was withdrawn as incorrect at 14:51 on 2026-08-26. PR #58 merged at 17:48 — three hours later — still saying `Fixes #57`, with the withdrawn evidence restated in the commit message.** #59 shipped it as 1.6.4's headline.

Full record in #60. Three independent problems:

1. **The premise was refuted.** A DeepSeek pass separated the variables #57's design had confounded — the negative failure tracks the **model** (`gpt-5.6-luna`), not the trigger list. On claude, `dicom` was 7/7 on that negative already.

2. **The edit could not have fixed the scenario.** `DICOM-NEG-01`'s prompt contains no "modality". Its own description states the cause: *"A fire here is a keyword-match misfire on `DICOM`"* — a local pydicom `.dcm`→PNG batch, explicitly "no servers and no integration engine".

3. **The supporting evidence was our own typo.** PR #58 cited `business-operations/SKILL.md` calling a lab analyzer "any modality" as proof the word is used loosely in the wild. It isn't — that was a terminology error in our own skill. "Modality" is imaging vocabulary: DICOM tag `(0008,0060)`, values CT/MR/US/CR/DX, and `dicom/SKILL.md:201` itself references `ScheduledProcedureStepSequence[1].Modality`. A lab analyzer is an *analyzer* or *instrument*. That line was the **only** non-imaging use of the word in the entire corpus — so 1.6.4 shipped an anti-trigger clause asserting something false into the skill text.

## What changed

Keeps 1.6.4's precision gains, drops the false premise, and aims the anti-trigger at the misfire that was actually observed.

- **`business-operations/SKILL.md`** — "any modality" → "any instrument". Fixes the terminology at its source, which is what made the word look ambiguous in the first place.
- **`dicom/SKILL.md`** frontmatter + §When to use — the anti-trigger is now local `.dcm` file work (pydicom/dcmtk, no association, no SCU/SCP, no IRIS) = file processing, not integration. This is the case we have actual evidence for.
- **`interop/SKILL.md`** router row — same carve-out.

`imaging modality (the device)` and `modality worklist` **stay**: both are precise, and dropping the false NOT-a-trigger clause restores recall on bare "modality", which is legitimate DICOM vocabulary.

## What this does not do

Recall is still unmeasured. The campaign has only ever measured **1.5.9 and 1.6.1** — 1.6.2, 1.6.3 and 1.6.4 have no fire-rate pass behind them. `DICOM-FIRE-01`, `DICOM-FIRE-02-IMPL` and `DICOM-NEG-01` should be run against whatever version follows this.

## Method note

"Consistent across two CLIs" is only evidence about a skill if the **model** also varies. And a PR whose issue is withdrawn while it is in flight needs its premise re-checked before merge, not just its diff.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)