### PR TITLE
release: 1.6.5 — dicom anti-trigger corrected; "modality" is imaging vocabulary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.6.4"
+    "version": "1.6.5"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Version bump only — content landed in #61.

## What's in 1.6.5

- **`dicom`** — 1.6.4's anti-trigger was built on withdrawn evidence. #57 was closed `NOT_PLANNED` at 14:51 on 2026-08-26; PR #58 merged at 17:48 still saying `Fixes #57`. It also cited our own terminology error as supporting proof. Replaced with the misfire actually observed in `DICOM-NEG-01`: local `.dcm` file work (pydicom/dcmtk, no association, no SCU/SCP, no IRIS) is file processing, not integration.
- **`business-operations`** — a lab analyzer is an *instrument*, not "a modality". Modality is imaging vocabulary (DICOM tag `(0008,0060)`); this was the only non-imaging use of the word in the corpus, and it was what made the term look ambiguous.
- **`interop`** — router row carve-out matched to the above.

`imaging modality (the device)` and `modality worklist` are retained. Dropping the false NOT-a-trigger clause restores recall on bare "modality", which is legitimate DICOM vocabulary.

## Known gap

Recall is unmeasured. The eval campaign has only ever run **1.5.9 and 1.6.1** — 1.6.2, 1.6.3 and 1.6.4 have no fire-rate pass behind them. A dicom-targeted pass against 1.6.5 is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)