### PR TITLE
docs: repoint fourteen dead cross-skill references at real sections

### DIFF
--- a/skills/business-operations/SKILL.md
+++ b/skills/business-operations/SKILL.md
@@ -20,7 +20,7 @@ What's the destination?
 │       BO method calls the gateway and runs parameterized SQL
 ├── HL7 v2.x over TCP/MLLP → EnsLib.HL7.Operation.TCPOperation
 ├── HL7 v2.x to file → EnsLib.HL7.Operation.FileOperation
-├── SOAP web service → use iris-interop-soap-bo (SOAP wizard from WSDL)
+├── SOAP web service → use the soap-bo skill (SOAP wizard from WSDL)
 ├── REST endpoint → custom BO + EnsLib.REST.OutboundAdapter (or HTTP.OutboundAdapter)
 ├── Plain file → EnsLib.File.OutboundAdapter
 └── Custom protocol → custom BO extending Ens.BusinessOperation
@@ -125,7 +125,7 @@ Without a finite timeout, in-flight retries against an unreachable target accumu
 
 ### Timeout precedence — BO timeouts MUST be smaller than calling BP
 
-A BO's `Response Timeout` and `Failure Timeout` MUST be strictly smaller than the calling BP's wait timeout — whoever times out first owns the error context, and only a BO-first timeout carries diagnostic detail up the chain. Set BO timeouts last, after the calling BP's timeout is fixed. Mechanism and the BP-side view: see `bpl` §"Timeouts".
+A BO's `Response Timeout` and `Failure Timeout` MUST be strictly smaller than the calling BP's wait timeout — whoever times out first owns the error context, and only a BO-first timeout carries diagnostic detail up the chain. Set BO timeouts last, after the calling BP's timeout is fixed. Mechanism and the BP-side view: see `bpl` §"Timeout precedence".
 
 ### `ReplyCodeActions` defaults can swallow application errors (HL7 BO)
 
@@ -260,7 +260,7 @@ The BP is the documentation anchor; `Credentials` is just the secret holder. Aud
 </Item>
 ```
 
-`EnsLib.JavaGateway.Service` is **deprecated in IRIS 2026.1** — the item can be kept as a thin wrapper pointing at `%JDBC Server`, but the long-term direction is to reference the ELS directly from the BO. See `iris-interop-production-lifecycle §Default scaffolds`.
+`EnsLib.JavaGateway.Service` is **deprecated in IRIS 2026.1** — the item can be kept as a thin wrapper pointing at `%JDBC Server`, but the long-term direction is to reference the ELS directly from the BO. See `production-lifecycle` §"Default scaffolds".
 
 ## JDBC type marshalling — gotchas
 

--- a/skills/lookup-tables/SKILL.md
+++ b/skills/lookup-tables/SKILL.md
@@ -147,7 +147,7 @@ Pin every row a DTL relies on with a `%UnitTest` (see the assertion pattern abov
 
 ## Naming conventions
 
-Apply the canonical naming convention (xref `iris-interop` router §1.1) to lookup tables. The table **name** should describe the mapping clearly enough that a reader of a DTL knows what's being translated without opening the table.
+Apply the canonical naming convention (xref `interop` §"Naming convention") to lookup tables. The table **name** should describe the mapping clearly enough that a reader of a DTL knows what's being translated without opening the table.
 
 | Pattern | Example | When |
 |---|---|---|
@@ -215,4 +215,4 @@ This raises on miss instead of silently propagating an empty value.
 - `bpl` — also consumes lookups in routing rules and BPL conditions
 - `production-lifecycle` — lookup tables are part of the production export
 - `business-operations` — `ExecuteQueryParmArray` pattern for SQL-sourced refresh jobs
-- `iris-interop` — naming conventions (router §1.1)
+- `interop` — §"Naming convention"

--- a/skills/message-search-debug/SKILL.md
+++ b/skills/message-search-debug/SKILL.md
@@ -225,7 +225,7 @@ The global `^ISCSOAP("Log")` toggle traces all SOAP traffic for the namespace, m
 
 **Better:** per-BO SOAP tracing via a customer-internal copy of `%SOAP.WebClient`:
 
-1. Copy `%SOAP.WebClient` to a customer namespace (e.g. `Alt.SOAP.WebClient`) — `Alt` is the canonical reserved package for patched system classes (xref `iris-interop` §1.2).
+1. Copy `%SOAP.WebClient` to a customer namespace (e.g. `Alt.SOAP.WebClient`) — `Alt` is the canonical reserved package for patched system classes (xref `interop` §"Reserved package names").
 2. Change the generated SOAP proxy's superclass from `%SOAP.WebClient` to `Alt.SOAP.WebClient`.
 3. Add a `SoapLogFile` setting on each BO; toggle the global only inside that BO's `OnMessage`:
 

--- a/skills/messages/SKILL.md
+++ b/skills/messages/SKILL.md
@@ -191,7 +191,7 @@ When a message class is projected to XML (SOAP payloads, REST XML responses, fil
 | `XMLIGNORENULL = 1` (class-level, NOT property-level) | Empty-string properties appear as empty elements (`<Field/>`) instead of being omitted. | When the partner schema requires the elements to be present even when empty. **Caveat**: for `list Of <T>` collections where every item is empty, the list element is still omitted — there is no clean way to force its presence except manual XML manipulation. |
 | `CONTENT = "STRING"` on a `%Stream.GlobalCharacter` property | Wraps content in `<![CDATA[...]]>`. | When the payload is XML you don't want re-escaped (e.g. CDA inside a SOAP envelope). |
 | `CONTENT = "ESCAPE"` on a `%Stream.GlobalCharacter` property | XML-escapes the text. | For free-text fields that may contain `<` or `&`. |
-| `OUTPUTTYPEATTRIBUTE = 0` (class-level on SOAP proxy) | Suppresses `xsi:type` attributes on every element. | When the partner SOAP server rejects messages with `xsi:type` (some SAP, some vendor servers — see `iris-interop-soap-bo §6.1.2`). |
+| `OUTPUTTYPEATTRIBUTE = 0` (class-level on SOAP proxy) | Suppresses `xsi:type` attributes on every element. | When the partner SOAP server rejects messages with `xsi:type` (some SAP, some vendor servers — see `soap-bo` §"Vendor rejects `xsi:type` attributes"). |
 
 Worked example: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch05_bpl_dtl/xml-projection-settings.cls`.
 

--- a/skills/production-lifecycle/SKILL.md
+++ b/skills/production-lifecycle/SKILL.md
@@ -374,7 +374,7 @@ Git 2.35+ verifies the repository owner matches the running user. IRIS running a
 
 Custom HL7 schemas edited via the Management Portal are stored **in the namespace**, not on disk. They are not auto-exported by source-control integration. After every schema edit, manually `Export` to the SCM root and commit alongside related class changes.
 
-Failure to export is a silent loss-of-work risk on the next namespace refresh. See `iris-interop-hl7-schemas §2.2` for the full risk discussion.
+Failure to export is a silent loss-of-work risk on the next namespace refresh. See `hl7-schemas` §"Schemas are NOT auto-exported to source control" for the full risk discussion.
 
 ## Migration of interop productions
 
@@ -477,4 +477,4 @@ If the installer must run identically on Linux and Windows, prefer driving it fr
 - `alerting` — alert circuit baseline (alert router + sink BO + monitor service)
 - `hl7-schemas` — schema export discipline (NOT auto-exported)
 - `security` — credentials, instance keys, namespace-level security boundaries
-- `iris-interop` — naming convention (§1.1) and reserved packages (§1.2)
+- `interop` — §"Naming convention" and §"Reserved package names"

--- a/skills/security/SKILL.md
+++ b/skills/security/SKILL.md
@@ -142,7 +142,7 @@ Some e-invoicing and public-sector signature workflows (e.g. Spanish TicketBAI, 
 - **Keeping the server cert in the trust chain `.PEM`** → annual cert rotation forces an IRIS config change.
 - **Treating `CSPSystem` as a normal account** (deleting it, rotating its password from a human-account script) → Web Gateway breaks.
 - **GUID-style AssertionIDs on SAML 1.1** → fixed-format underscore-prefixed IDs required by many partners.
-- **Trusting the WSDL's response namespace blindly** — SOAP servers often return a different namespace than the WSDL declares. Capture an actual response and override (see `iris-interop-soap-bo §6.1.6`).
+- **Trusting the WSDL's response namespace blindly** — SOAP servers often return a different namespace than the WSDL declares. Capture an actual response and override (see `soap-bo` §"`RESPONSENAMESPACE` doesn't match what the vendor actually returns").
 
 ## When NOT to use this skill — fall back to docs
 

--- a/skills/soap-bo/SKILL.md
+++ b/skills/soap-bo/SKILL.md
@@ -144,17 +144,17 @@ Worked example: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch06_adapters/soap
 
 Vendor services occasionally return errors unless the SOAP envelope's namespace prefix is literally `urn` (not the default `s` or `soap` the wizard emits).
 
-**Fix**: instantiate the SOAP client manually so the namespace prefix can be set explicitly before invocation. Same instantiation pattern as the SAML custom-header example (see `iris-interop-security §11.3`).
+**Fix**: instantiate the SOAP client manually so the namespace prefix can be set explicitly before invocation. Same instantiation pattern as the SAML custom-header example (see `security` §"Custom security header on a generated SOAP BO").
 
 ### Generated classes ARE meant to be edited
 
-The naming convention's reserved `<Pkg>.<SubPkg>.WSC<Name>` sub-package (see `iris-interop` §1.1) is partly motivated by these patches. Generated SOAP/XSD classes need to be **regeneratable in isolation** (delete the sub-package, re-run the wizard, re-apply patches) AND every patch needs to be applied each time.
+The naming convention's reserved `<Pkg>.<SubPkg>.WSC<Name>` sub-package (see `interop` §"Naming convention") is partly motivated by these patches. Generated SOAP/XSD classes need to be **regeneratable in isolation** (delete the sub-package, re-run the wizard, re-apply patches) AND every patch needs to be applied each time.
 
 Document every patch in the class header with a stable tag (e.g. `///PYD20260513:` prefix on each modified line) — a grep across the regenerated classes finds the patches to re-apply by tag, not by line position.
 
 ## SOAP tracing per BO
 
-For diagnosing wire-level issues on a SOAP BO, use a per-BO `SoapLogFile` setting rather than the namespace-wide `^ISCSOAP("Log")` toggle. Each BO writes to its own log file path, settable at runtime from the portal — covered in `iris-interop-message-search-debug §6.2`.
+For diagnosing wire-level issues on a SOAP BO, use a per-BO `SoapLogFile` setting rather than the namespace-wide `^ISCSOAP("Log")` toggle. Each BO writes to its own log file path, settable at runtime from the portal — covered in `message-search-debug` §"Per-BO SOAP tracing".
 
 ## Canonical pattern — calling the SOAP BO
 
@@ -286,4 +286,4 @@ When you're on the **other side** — exposing a SOAP service that an external c
 - `unit-tests` — testing the generated BO methods
 - `message-search-debug` — verifying end-to-end SOAP calls; per-BO SOAP tracing
 - `security` — attaching SAML / WS-Security custom headers to the generated proxy
-- `iris-interop` — generated-class sub-package naming convention (§1.1, `WSC<Name>` pattern)
+- `interop` — §"Naming convention" (generated-class sub-package, `WSC<Name>` pattern)


### PR DESCRIPTION
Closes #63. The issue described **8** dead pointers; validating the whole corpus mechanically turned up **14**.

## The families

**1. `iris-interop-<name> §N.N` — 7 pointers.** A pre-rename skill id that matches neither convention in use (bare name in prose, 250 uses; plugin-qualified `iris-interop-skills:<name>` in the router and routing mandates, 28 uses), combined with a section-numbering scheme no skill file uses any more. Both halves dead.

**2. `iris-interop §1.1` / `§1.2` — 6 pointers.** Found while validating, not in the original issue. The router's directory is `interop`, so `` `iris-interop` `` resolves to nothing, and the numbering is equally dead. All six meant §"Naming convention" or §"Reserved package names".

**3. The one 1.6.2 introduced — 1 pointer.** `business-operations` deferred to `` `bpl` §"Timeouts" ``; the real heading is `Timeout precedence — BO timeout MUST be smaller than calling BP`. Every other pointer that release added is a correct prefix of its real heading — this was the only one that wasn't.

## What changed

All fourteen now name a **real section title** rather than a number, so they survive a section moving. Two pointers into `soap-bo` include the backticks that are in those headings verbatim, so a literal grep finds them.

## Verification

Mechanical, over the whole corpus:

```
section pointers: 20 resolve, 0 broken
```

The remaining `§5.4 in examples/README.md` references are a different index and were checked separately — `BestPractices/examples/README.md:25` and `ch05_bpl_dtl/objectscript-trycatch.cls` both exist.

## Scope

Navigation only. No rule loses its statement — in every case the imperative is stated in place *before* the pointer, and the pointer defers only mechanism or a worked example. Pointer rot, not a content gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)