### PR TITLE
docs(unit-tests): restore the boundary method to the canonical DTL example

### DIFF
--- a/skills/unit-tests/SKILL.md
+++ b/skills/unit-tests/SKILL.md
@@ -228,7 +228,16 @@ Method TestHappyPath()
     Do $$$AssertEquals(tTarget.GetValueAt("PV1:3"), "ICU", "PV1:3 should be Department")
 }
 
-/// Add one rejection/boundary Test* method per spec clause — never ship happy-path-only.
+Method TestEmptyDepartment()
+{
+    Set tSrc = ##class(MyApp.Msg.PatientCensusRequest).%New()
+    Set tSrc.PatientId = "P12345"
+    Set tSC = ##class(MyApp.DT.PatientCensusToADT).Transform(tSrc, .tTarget)
+    Do $$$AssertStatusOK(tSC)
+    Do $$$AssertEquals(tTarget.GetValueAt("PV1:3"), "", "Empty department should map to empty PV1:3")
+}
+
+/// One boundary method is the MINIMUM, not the target — add one Test* per spec clause.
 /// Completeness checklist and full skeletons (DTL, routing rule, BO, BPL): see `tdd`.
 }
 ```


### PR DESCRIPTION
Closes #64.

## The problem

1.6.2's compaction (`d51e7b5`) removed `TestEmptyDepartment` from the canonical DTL block in `unit-tests` and left this in its place:

```objectscript
/// Add one rejection/boundary Test* method per spec clause — never ship happy-path-only.
```

So the file ended up showing **one happy-path method** while *telling* the reader not to ship happy-path-only.

## Why this removal was different from the other ~37

The compaction's premise — dedupe restatements to an owning section — holds for the rest of that release. It does not hold here, because the second method was never a restatement of the first. It was the **demonstration** of the boundary-assert teaching, and the comment that replaced it only asserts that teaching.

Code-generating models imitate an example block far more reliably than they obey prose sitting beside it. And the resulting shape is the one `tdd/SKILL.md:145` explicitly calls out:

> a `Test*` method whose only assertion is `$$$AssertStatusOK(sc)` … passes against an implementation that silently drops every field

## Why the cross-file pointer doesn't cover it

The replacement worked example lives in `tdd` (`:192-199`, plus the checklist at `:123-147`). But `unit-tests` is described as "%UnitTest framework — runner, storage, results" — it is exactly the skill pulled in to answer "how do I write the test class", and `tdd` may never be loaded in that turn.

## What changed

Restores the method, keeps the generalising comment, and rewords it so one boundary case reads as the floor rather than the goal:

> `/// One boundary method is the MINIMUM, not the target — add one Test* per spec clause.`

## Measurement

This is a hypothesis about generation behaviour, not a verified defect — and it is the one finding from the 1.6.2 audit worth an eval: compare `Test*`-methods-per-component on plugin 1.6.1 vs current. Nothing since 1.6.1 has been measured. That pass belongs to the eval-campaign session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)