### PR TITLE
docs: fix three corpus contradictions that silently produce broken productions

### DIFF
--- a/skills/alerting/SKILL.md
+++ b/skills/alerting/SKILL.md
@@ -36,13 +36,13 @@ Production XML excerpt for the alert circuit:
 <Item Name="Ens.Alert" Category="..." ClassName="EnsLib.MsgRouter.RoutingEngine"
       PoolSize="1" Enabled="true">
   <Setting Target="Host" Name="BusinessRuleName">MyApp.Rule.AlertRouting</Setting>
-  <!-- NO SendAlertOnError setting -->
+  <!-- deliberately NO AlertOnError here — this item IS the alert circuit -->
 </Item>
 
 <Item Name="BO.AlertEmail" Category="..." ClassName="EnsLib.EMail.AlertOperation"
       PoolSize="1" Enabled="true">
   <Setting Target="Host" Name="Recipient">oncall@example.org</Setting>
-  <!-- NO SendAlertOnError setting -->
+  <!-- deliberately NO AlertOnError here — this item IS the alert sink -->
 </Item>
 
 <Item Name="Ens.ProductionMonitorService" Category="..."

--- a/skills/business-services/SKILL.md
+++ b/skills/business-services/SKILL.md
@@ -27,10 +27,15 @@ What's the input?
 
 ## Canonical pattern — custom BS skeleton
 
+This is the **subclass** case: it extends the prebuilt `EnsLib.RecordMap.Service.FileService`, which
+already supplies `EnsLib.File.InboundAdapter`. Do **not** also declare `Parameter ADAPTER` — that
+keyword names an *adapter*, and `…Service.FileService` is a Business Service, not one. A BS that
+needs a bare adapter instead extends `Ens.BusinessService` and declares e.g.
+`Parameter ADAPTER = "EnsLib.File.InboundAdapter"`.
+
 ```objectscript
-Class MyApp.BS.PatientCensusFromCSV Extends Ens.BusinessService
+Class MyApp.BS.PatientCensusFromCSV Extends EnsLib.RecordMap.Service.FileService
 {
-Parameter ADAPTER = "EnsLib.RecordMap.Service.FileService";
 Parameter SETTINGS = "TargetConfigNames:Basic,RequiredField:Basic";
 
 Property TargetConfigNames As %String(MAXLEN=1000);

--- a/skills/production-lifecycle/SKILL.md
+++ b/skills/production-lifecycle/SKILL.md
@@ -172,16 +172,19 @@ XData ProductionDefinition
         PoolSize="1" Enabled="true">
     <Setting Target="Adapter" Name="FilePath">/data/in</Setting>
     <Setting Target="Host" Name="TargetConfigNames">Router.Census</Setting>
+    <Setting Target="Host" Name="AlertOnError">1</Setting>
   </Item>
 
   <Item Name="Router.Census" Category="MyApp" ClassName="EnsLib.MsgRouter.RoutingEngine"
         PoolSize="1" Enabled="true">
     <Setting Target="Host" Name="BusinessRuleName">MyApp.Rule.RoutingCensus</Setting>
+    <Setting Target="Host" Name="AlertOnError">1</Setting>
   </Item>
 
   <Item Name="BO.SQL" Category="MyApp" ClassName="MyApp.BO.WriteCensusToSQL"
         PoolSize="1" Enabled="true">
     <Setting Target="Adapter" Name="JGService">Util.JDBCGateway</Setting>
+    <Setting Target="Host" Name="AlertOnError">1</Setting>
   </Item>
 
   <Item Name="Util.JDBCGateway" Category="MyApp" ClassName="EnsLib.JavaGateway.Service"

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -371,9 +371,11 @@ error. Work the cause instead, in this exact order:
 3. **Act on the tool's `hint` / `candidates`.** `iris_test` returns these on a miss — they list the
    names it *can* see. Pick the matching candidate and re-run with that exact name; do not guess a third
    variant or fall back to running `Run()` from the terminal.
-4. **Verify the superclass.** The class must extend `%UnitTest.TestProduction` (or `%UnitTest.TestCase`)
-   and have at least one `Test*` method. A class that extends the wrong base, or whose methods are not
-   prefixed `Test`, compiles but exposes zero tests.
+4. **Verify the superclass.** The class must extend `%UnitTest.TestProduction` — never
+   `%UnitTest.TestCase`, which is not an escape hatch from a `#5001` here any more than anywhere
+   else (see §"Baseline class" and the fixed-points rule below) — and have at least one `Test*`
+   method. A class that extends the wrong base, or whose methods are not prefixed `Test`, compiles
+   but exposes zero tests.
 5. Only after 1–4 — if it still reports `NO_TESTS_FOUND` — STOP and report the blocker: 3 consecutive
    failed attempts at the same goal is the cap. Mechanism: see `interop` (section "Stop on repeated
    failure"). Do not loop, and do not switch routes to "work around" it — not `$SYSTEM.OBJ.Load` /


### PR DESCRIPTION
Closes #67, closes #68, closes #69.

Three places where a skill contradicts the plugin's own conventions. All three fail **silently** — the class compiles, the run reports done, and the thing that was supposed to happen never does. That is the failure shape this corpus exists to prevent, so it is worth being blunt that we shipped three of them.

## 1. The canonical BS skeleton named a Business Service as its adapter (#67)

```objectscript
Class MyApp.BS.PatientCensusFromCSV Extends Ens.BusinessService
Parameter ADAPTER = "EnsLib.RecordMap.Service.FileService";   // <-- not an adapter
```

`EnsLib.RecordMap.Service.FileService` is a prebuilt Business Service. The plugin says so three times: `component-map:26` puts it in the **Superclass** column with `EnsLib.File.InboundAdapter` as the adapter; `business-services:279` repeats it; and `business-services:141` calls this very block **"the subclass case"**. Its `OnProcessInput(pInput As EnsLib.RecordMap.Base, …)` is the subclass signature — so the block was internally incoherent, not just mislabelled.

**It propagated.** Every `Parameter ADAPTER` in agent-authored code across the corpus:

```
26  EnsLib.File.OutboundAdapter
16  EnsLib.File.InboundAdapter
13  EnsLib.SQL.OutboundAdapter
 6  EnsLib.RecordMap.Service.FileService   <-- copied from this skeleton
```

All six are shape-identical to the skeleton. None hit an error — nothing in grading exercises the poll, and the 2026-08-27 review counted them **conformant** because its classifier only checked the parameter was present.

Now extends the service class, drops `ADAPTER`, and says when each form applies.

## 2. `SendAlertOnError` does not exist, and no scaffold set the real setting (#68)

`alerting` gave the setting name as `SendAlertOnError` — which appears nowhere else in the repo or in any generated code. The real name is `AlertOnError` (`conformance-review:72` CR-3, `bpl:213`, the example XML, and every high-scoring generated production).

It appeared exactly twice, **both saying where not to put it**, so the only form a reader could carry away was a name that does not exist. Most likely the portal label "Send Alert on Error" leaking into XML.

Compounding it: the canonical production scaffold set `AlertOnError` on **zero of six** items. Measured: **80 of 84** runs containing a production have no `AlertOnError` anywhere (95%) — recorded in the code-quality review as "the single worst gap". A production wired per our own scaffold gets an `Ens.Alert` router and a sink BO that never receive anything.

Fixed the name, and fed the circuit on the three error-bearing hosts (BS, Router, BO) while deliberately leaving it off the two that *are* the alert circuit.

## 3. The `NO_TESTS_FOUND` ladder licensed `%UnitTest.TestCase` (#69)

Step 4 read: "must extend `%UnitTest.TestProduction` **(or `%UnitTest.TestCase`)**".

The same file forbids that four times, including `:415` — *"Nor is `%UnitTest.TestCase` an escape hatch for a compile error … fixed points"* — plus the frontmatter, `:10-12`, and `component-map:46`, and bootstrap convention 5.

Placement is what made it load-bearing: step 4 is reached only after two failures, where the documented commonest cause is `#5001: Parameter PRODUCTION must be specified`. So the ladder handed the agent the one change that makes `#5001` disappear, at its moment of maximum pressure. `iris-interop-dev#62`'s 16-run table shows the outcome is decided entirely by class shape: `%UnitTest.TestCase` → ran nothing.

## Verification

Negative greps, all clean: no `SendAlertOnError`, no `ADAPTER = "EnsLib.RecordMap…`, no `or \`%UnitTest.TestCase\`` remaining.

**Not verified against live IRIS.** The dev instance (`iris-dev-environment`) is down, and the only healthy IRIS containers belong to the eval harness mid-battery, so I did not start a competing instance. Nothing here depends on an IRIS probe — every claim is an internal contradiction, settled by the corpus disagreeing with itself and by the generated-code counts. Two *related* claims that do need a probe are deliberately **not** in this PR and will be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)