### PR TITLE
release: 1.6.6 — silent-failure fixes from the first systematic corpus audit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.6.5"
+    "version": "1.6.6"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Version bump only — content landed in #65, #66, #70, #73.

## Why this release exists

The issue queue was **empty**. Three parallel read-only audits — the 1.6.2 compaction, the 1.6.0–1.6.3 release justifications, and a hunt for unfiled defects — found seven real problems, **three of which fail silently**: the class compiles, the run reports done, and the thing that was supposed to happen never does.

## What's in 1.6.6

| | |
|---|---|
| **#67** | The canonical BS skeleton named a **Business Service as its adapter**. `business-services:141` calls that very block "the subclass case". **6 agent-authored classes copied it verbatim** — none errored, because nothing exercises the poll |
| **#68** | `alerting` named the setting `SendAlertOnError`, which exists nowhere else; the real name is `AlertOnError`. It appeared only twice, *both saying where not to put it*. The canonical scaffold set it on **zero of six** items — **80 of 84** generated productions have no alert wiring |
| **#69** | The `NO_TESTS_FOUND` ladder licensed `%UnitTest.TestCase` at the exact step where `#5001` is the documented commonest cause — the one change that makes `#5001` disappear |
| **#64** | The `unit-tests` canonical DTL example had been left happy-path-only — the shape `tdd:145` calls an anti-pattern |
| **#71** | Three skills contradicting our own conventions: the alert router's class, DTL-as-BP advice against CR-1/CR-4, `.Rule` scaffolds against CR-9's `.RUL` |
| **#63** | 14 dead cross-skill pointers repointed at real sections; corpus-wide check now **20 resolve, 0 broken** |

## Audit verdicts worth recording

- **1.6.2's compaction was sound.** ~38 removals traced; no bootstrap non-negotiable lost. Two defects (#63's pointer, #64's example), both fixed here.
- **The #57 withdrawn-premise failure is not systemic.** 1.6.0, 1.6.1 and 1.6.2 are sound; 1.6.3 is sound on four of five PRs. **1.6.1 is the positive control** — issue #38 was withdrawn by its author and PR #40 merged 82 minutes later carrying the *corrected* mechanism.
- One weak justification found and **corrected on the record, not reverted** (#50/#55): "13/38 runs copying this template" — the copy mechanism was never observed, and the guard rate is flat at 1.6.5 (4/12 vs 22/64).

## Known gaps

- **#72 remains open** — two claims need a live-IRIS probe (the example bank's alert-circuit class names; the `DebugRunTestCase` `/recursive=1` rule, which IRIS's own `Run()` appears to violate). The dev instance is down and the only healthy IRIS containers belong to the eval harness mid-battery.
- **Nothing since 1.6.1 has been measured.** 1.6.2–1.6.6 have no fire-rate or build-quality pass behind them. That is now the single largest outstanding risk, and it belongs to the eval-campaign session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)