### PR TITLE
docs: four corrections verified against live IRIS 2026.1

### DIFF
--- a/BestPractices/BestPractices_Interop_IRIS.md
+++ b/BestPractices/BestPractices_Interop_IRIS.md
@@ -133,7 +133,7 @@ Every production must include at minimum:
 
 - `Ens.ProductionMonitorService` running every 30 s (default).
 - An `Ens.Alert` business process configured to handle `Ens.AlertRequest` messages.
-- An alert-output BO (typically `EnsLib.Email.AlertOperation` for email; `Ens.Alarm` for paging/SMS).
+- An alert-output BO (typically `EnsLib.EMail.AlertOperation` for email; `Ens.Alarm` for paging/SMS).
 
 See §7 for the alert circuit details and the "always-on / dedupe" rules.
 
@@ -620,7 +620,7 @@ In every Business Host of the production, enable "Send Alert on Error". The exce
 Canonical wiring:
 
 - `Ens.Alert` implemented as `EnsLib.MsgRouter.RoutingEngine`.
-- `EnsLib.Email.AlertOperation` BO sends `Ens.AlertRequest` messages by email to a distribution list.
+- `EnsLib.EMail.AlertOperation` BO sends `Ens.AlertRequest` messages by email to a distribution list.
 - A **filter routing rule** dedupes alerts to avoid mailbox saturation (see §7.2 for the FunctionSet).
 
 - **Validity.** Still valid.

--- a/BestPractices/examples/ch07_alerting/alert-circuit-production.xml
+++ b/BestPractices/examples/ch07_alerting/alert-circuit-production.xml
@@ -5,7 +5,7 @@
 
      Canonical alert circuit:
        - Ens.Alert is a EnsLib.MsgRouter.RoutingEngine (dedup via routing rules).
-       - EnsLib.Email.AlertOperation sends Ens.AlertRequest messages by email.
+       - EnsLib.EMail.AlertOperation sends Ens.AlertRequest messages by email.
        - Filter routing rule uses examples/ch07_alerting/alert-dedup-functionset.cls
          to dedupe alerts (PYD.FilterAlerts.AlreadyReportedErr / AlreadyReportedPerSession).
        - CRITICAL: Ens.Alert AND the BO that sends the alert must have "Send Alert on Error"
@@ -18,7 +18,7 @@
 
     <!-- ProductionMonitorService — heartbeat for the production health -->
     <Item Name="Ens.ProductionMonitorService" Category="Alerting"
-          ClassName="Ens.ProductionMonitorService"
+          ClassName="Ens.MonitorService"
           PoolSize="1" Enabled="true" Comment="§1.6 baseline">
     </Item>
 
@@ -32,8 +32,8 @@
     </Item>
 
     <!-- AlertOperation — Send Alert on Error MUST be DISABLED here -->
-    <Item Name="EnsLib.Email.AlertOperation" Category="Alerting"
-          ClassName="EnsLib.Email.AlertOperation"
+    <Item Name="EnsLib.EMail.AlertOperation" Category="Alerting"
+          ClassName="EnsLib.EMail.AlertOperation"
           PoolSize="1" Enabled="true"
           Comment="Sends Ens.AlertRequest messages to the distribution list.">
       <Setting Target="Host" Name="AlertOnError">false</Setting>
@@ -66,7 +66,7 @@
         </rule>
         <rule name="forward" disabled="false">
           <when condition="1">
-            <send transform="" target="EnsLib.Email.AlertOperation"/>
+            <send transform="" target="EnsLib.EMail.AlertOperation"/>
           </when>
         </rule>
       </ruleSet>

--- a/skills/alerting/SKILL.md
+++ b/skills/alerting/SKILL.md
@@ -15,7 +15,7 @@ The user is wiring `Ens.Alert`, adding an `EnsLib.EMail.AlertOperation`, asking 
 
 Every production must include at minimum:
 
-- **`Ens.ProductionMonitorService`** — runs every 30 s (default). Surfaces per-component state to the production monitor screen.
+- **`Ens.ProductionMonitorService`** — the conventional *item* name; runs every 30 s (default) and surfaces per-component state to the production monitor screen. Two **different** real classes exist here and are easy to conflate — IRIS's own descriptions: `Ens.MonitorService` *"checks all hosts for inactivity"* (the `ClassName` wired below), and `Ens.ProductionMonitorService` *"monitor service for the production status … calls UpdateProduction once it notices the production is not up-to-date"*. Both are real, so a wrong pick fails silently rather than at load.
 - **`Ens.Alert`** — an `EnsLib.MsgRouter.RoutingEngine` configured to handle `Ens.AlertRequest` messages.
 - **At least one alert sink BO** — typically `EnsLib.EMail.AlertOperation` for email; can be SMS, file, a paging system. Multiple sinks fan out through the router.
 

--- a/skills/unit-tests/SKILL.md
+++ b/skills/unit-tests/SKILL.md
@@ -120,7 +120,16 @@ SELECT MyApp_Bootstrap_RunTestClass('MyApp.Tests.DT.Censo2Menus')
 
 ### Qualifier syntax pitfall — booleans only
 
-The `DebugRunTestCase` qualifier flags are **boolean** — write `/noload/norecursive/nodelete`. Do NOT write `/noload=0` or `/recursive=1`. The `=value` form throws `ERROR #5001: can not mix negated form with value`. The qualifier is either present (true) or absent (default false).
+`ERROR #5001: can not mix negated form with value` fires only when a **negated** qualifier carries a
+value — `/noload=0`, `/norecursive=1`. The `no` prefix already encodes the value, so a second one is
+a contradiction.
+
+The plain form takes a value perfectly well: IRIS's own `%UnitTest.TestProduction.Run()` calls
+`DebugRunTestCase("", class, "/debug=0/recursive=0")`. Verified on IRIS 2026.1 —
+`DebugRunTestCase(…, "/recursive=1")` returns OK, `DebugRunTestCase(…, "/noload=0")` returns #5001.
+
+So: write `/noload/norecursive/nodelete` for the negated form, or `/recursive=0/debug=0` for the
+plain form. Never `/no<x>=<value>`.
 
 ### `Try / Catch + Quit` pitfall inside runners
 
@@ -179,7 +188,14 @@ renders the same data graphically.
 
 The assertion macros are already in scope in any `%UnitTest.TestCase` subclass (`TestProduction` included) — **no `Include` line needed**. Verified on IRIS 2026.1:
 
-- **These exist**: `$$$AssertEquals`, `$$$AssertNotEquals`, `$$$AssertTrue`, `$$$AssertNotTrue`, `$$$AssertStatusOK`, `$$$AssertStatusNotOK`, `$$$LogMessage`.
+- **The full set** — every `Assert*`/`Log*` macro `%outUnitTest.inc` defines, enumerated from the
+  include itself on IRIS 2026.1 (`%UnitTest.TestCase` declares `Include %outUnitTest`, which is why
+  they are in scope without an `Include` line):
+  `$$$AssertEquals`, `$$$AssertNotEquals`, `$$$AssertTrue`, `$$$AssertNotTrue`, `$$$AssertStatusOK`,
+  `$$$AssertStatusNotOK`, `$$$AssertStatusEquals`, `$$$AssertFilesSame`,
+  `$$$AssertFilesSQLUnorderedSame`, `$$$AssertSuccess`, `$$$AssertFailure`, `$$$AssertSkipped`,
+  `$$$LogMessage`. Anything outside this list is not a macro — but do not "correct" code that uses
+  one that IS on it.
 - **These do NOT exist**: `$$$AssertNotNull`, `$$$AssertNotEmpty`, `$$$AssertGreater`. Inventing one fails the compile with `MPP5610 : Referenced macro not defined`. Compose from the real set instead: `$$$AssertTrue(val'="", ...)`, `$$$AssertTrue(x>y, ...)`.
 - Do **not** add `Include %UnitTest` as a recovery for `MPP5610` — it fails again with `MPP5635 : No include file '%UnitTest'` and points the fix at the wrong problem. The macro name itself is wrong; replace it.
 - Ens logging macros (in the BS/BP/BO code the tests exercise) are **UPPERCASE**: `$$$LOGINFO`, `$$$LOGERROR`, `$$$LOGWARNING`. `$$$LogError` is a different, nonexistent macro — casing matters, and the mixed-case slip produces the same `MPP5610`.


### PR DESCRIPTION
Closes #72. The dev instance is back, so these are settled by probe rather than by argument — and **two of the four came back differently than filed**, which is the whole reason they waited.

## 1. The qualifier rule was wrong (`unit-tests`)

The skill said: *"Do NOT write `/noload=0` **or `/recursive=1`**. The `=value` form throws `ERROR #5001`."*

Measured on IRIS 2026.1:

```
DebugRunTestCase("", "No.Such.TestClass", "/recursive=1")  ->  OK (no #5001)
DebugRunTestCase("", "No.Such.TestClass", "/noload=0")     ->  ERROR #5001: can not mix negated form with value: noload=0
```

`#5001` fires only when a **negated** qualifier carries a value — the `no` prefix already encodes it. The plain form takes a value fine, which is why IRIS's own `%UnitTest.TestProduction.Run()` calls `DebugRunTestCase("", class, "/debug=0/recursive=0")`.

So the skill was telling agents that shipped IRIS code is illegal, and misdirecting anyone debugging a real `#5001`.

## 2. The assertion-macro "inventory" listed 7 of 13 (`unit-tests`)

Enumerated from `%outUnitTest.inc` — the include `%UnitTest.TestCase` declares, which is *why* the macros are in scope without an `Include` line:

```
AssertEquals  AssertNotEquals  AssertTrue  AssertNotTrue  AssertStatusOK
AssertStatusNotOK  AssertStatusEquals  AssertFilesSame
AssertFilesSQLUnorderedSame  LogMessage  AssertSuccess  AssertFailure  AssertSkipped
```

Six were missing under a closed-list framing ("These exist"), which risks an agent "correcting" valid code that uses `$$$AssertFilesSame`. The "these do NOT exist" list is unchanged and still correct.

Worth noting: the finding predicted `$$$AssertStatusEqual`; the real name is `AssertStatusEquals`. Exactly the kind of near-miss that made probing rather than reasoning the right call.

## 3. `EnsLib.Email.AlertOperation` does not exist

Only `EnsLib.EMail.AlertOperation` does — capital M, `Super = Ens.Alerting.NotificationOperation`. Six sites in `BestPractices/` corrected. The skills already had it right; the example bank did not.

## 4. The monitor-service finding is **refuted as filed**

#72 claimed the example bank named a class that does not exist. **Both classes exist**, so this was never a `<CLASS DOES NOT EXIST>`:

| class | IRIS's own description |
|---|---|
| `Ens.MonitorService` | "Monitor Service. Checks all hosts for inactivity" |
| `Ens.ProductionMonitorService` | "monitor service for the production status … calls UpdateProduction once it notices the production is not up-to-date" |

They do different jobs. The example bank wired `ClassName="Ens.ProductionMonitorService"` where the skill it illustrates uses `Ens.MonitorService`. Aligned the example with the skill and documented the distinction — because two *real* classes means a wrong pick fails **silently**, which is worse than the load-time failure originally predicted.

I did **not** rename the production items. `Item Name="Ens.ProductionMonitorService" ClassName="Ens.MonitorService"` is confusing, but which item name is conventional is not something the probe settles, and guessing is what produced #57.

## Bonus: 1.6.6's fixes independently confirmed

The same session verified, no change needed:

- `AlertOnError` **is** a real property on `Ens.Host` and every host class; `SendAlertOnError` returns **zero** rows → **#68 was right**.
- `EnsLib.RecordMap.Service.FileService` has `Super = EnsLib.RecordMap.Service.Standard` — a Business Service, not an adapter → **#67 was right**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)