### PR TITLE
release: 1.6.7 — four corrections verified against live IRIS 2026.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.6.6"
+    "version": "1.6.7"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.6.6",
+      "version": "1.6.7",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Version bump only — content landed in #75.

Closes out the probe-blocked findings from the 1.6.6 audit, now that the dev IRIS is back. **Two of the four came back differently than filed** — which is why they waited for a probe rather than shipping on internal reasoning.

| | |
|---|---|
| `unit-tests` | `/recursive=1` **is legal**. `#5001` fires only when a *negated* qualifier carries a value. IRIS's own `Run()` calls `DebugRunTestCase("", class, "/debug=0/recursive=0")` — the skill was calling shipped IRIS code illegal |
| `unit-tests` | The assertion-macro "inventory" listed **7 of 13** under a closed "These exist" framing. Missing: `AssertStatusEquals`, `AssertFilesSame`, `AssertFilesSQLUnorderedSame`, `AssertSuccess`, `AssertFailure`, `AssertSkipped` |
| `BestPractices` | `EnsLib.Email.AlertOperation` does not exist — only `EnsLib.EMail.AlertOperation` (capital M). Six sites |
| `BestPractices` / `alerting` | Monitor-service finding **refuted as filed** — both classes are real and do different jobs. Aligned the example with the skill and documented the distinction |

## 1.6.6 independently confirmed

Same session, no change needed: `AlertOnError` **is** a real `Ens.Host` property (`SendAlertOnError` returns zero rows), and `EnsLib.RecordMap.Service.FileService` extends `EnsLib.RecordMap.Service.Standard` — a Business Service, not an adapter. So #67 and #68 were fixed correctly.

## State after this

Issue queue **empty**. The outstanding risk is unchanged and now the only one: **nothing since 1.6.1 has been measured** — 1.6.2 through 1.6.7 have no fire-rate or build-quality pass behind them. That belongs to the eval-campaign session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)