### PR TITLE
release: 1.7.0 — the example bank compiles

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.6.7"
+    "version": "1.7.0"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.6.7",
+      "version": "1.7.0",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.6.7",
+  "version": "1.7.0",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
**Minor bump, not a patch.** The file splits and class renames change the artefact set, not just its prose: 18 example files became 30 (one class per file), so anything pinning individual example paths will see moved content.

## What shipped

The bank went from **8 of 18 files compiling** to **30 of 30 clean** against live IRIS 2026.1. Every class was staged and compiled — nothing here is eyeballed.

Manifest: 20 skills / 8 hooks / 4 agents / 33 example artefacts (30 `.cls`).

Full account in #97. Two things worth repeating here:

- A read-only probe ran **before** any edit, and **refuted one of the three filed claims** — `HS.HC.FHIRSQL.Utils.Setup` was correct as written, and the suspected fix named a package that does not exist. It was left alone.
- The last two compile failures were **introduced by the repair pass itself** and caught by the compile gate on the way out. The gate paid for itself inside a single release.

## Known gap, deliberately left open

The bank still has **no BPL, DTL or routing-rule worked example** — the second half of #91, which stays open. Authoring three new canonical examples is design work, not repair.

## Not claimed

Behavioural verification. These examples compile; they have not been run in a production. Nothing since 1.6.1 has had a fire-rate or build-quality pass behind it — that measurement belongs to the eval-campaign session and is still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)