### PR TITLE
release: 1.8.0 — the bank is gated, and chapter 5 finally has BPL and DTL in it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.7.0"
+    "version": "1.8.0"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Minor bump: new deliverable sections (§5.6/§5.7/§5.8), four new example classes, and a new gate in CI.

## #91 closed

Chapter 5 was titled **"BPL & DTL patterns"** and contained neither. It now carries a custom BPL, a declared DTL, and a fan-out routing rule — all compiled against live IRIS 2026.1, and the DTL **executed** on both branches (the empty-input case is what proves the escaped `&amp;&amp;` evaluates rather than merely parsing).

## The bank is now gated

`scripts/validate_examples.py`:

- **tier 1** structural — runs in CI on every push to `BestPractices/`
- **tier 2** `--compile` — all 34 classes staged on a live IRIS, compiled, diffed against a recorded baseline, cleaned up in a `finally`

All 7 tier-1 checks were verified by negative control (each fails when its invariant breaks, and fires only its own check), and tier 2 was verified against a deliberately broken BPL. See #99.

Manifest: 20 skills / 8 hooks / 4 agents / **37 example artefacts (34 `.cls`, 34/34 compiling)**.

## Not claimed

- CI runs **tier 1 only** — the runner has no IRIS. Tier 2 is a local pre-release step.
- The BPL and routing rule are compiled and generator-verified, **not** run in a production. Only the DTL is behaviourally verified.
- Nothing since 1.6.1 has had a fire-rate or build-quality pass behind it. That measurement belongs to the eval-campaign session and is still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)