### PR TITLE
fix(hooks): forcing function for the conformance pass (#96) + tier 2 in CI (#101)

### DIFF
--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -1,13 +1,12 @@
-# validate-examples: structural gate over the BestPractices example bank.
+# validate-examples: the gate over the BestPractices example bank.
 #
-# Runs tier 1 only. Tier 2 (compile every example against a live IRIS) needs an
-# IRIS instance with Interoperability + HL7, which this runner does not have —
-# run it locally before a release:
+#   structural  tier 1, no IRIS, ~1s — every push
+#   compile     tier 2, real IRIS in a container — every push
 #
-#   python3 scripts/validate_examples.py --compile
-#
-# See scripts/validate_examples.py for what each check does and, more importantly,
-# why each one is written in its narrow form.
+# Tier 2 is the check that matters. Tier 1 catches structure; only a compiler would have
+# caught the 10-of-18 failures found in 1.7.0, or the two #5478 signature traps that the
+# repair pass itself introduced. See scripts/validate_examples.py for what each check does
+# and why each is written in its narrow form.
 
 name: validate-examples
 
@@ -16,11 +15,14 @@ on:
     paths:
       - 'BestPractices/**'
       - 'scripts/validate_examples.py'
+      - 'scripts/examples_baseline.json'
       - '.github/workflows/validate-examples.yml'
   pull_request:
     paths:
       - 'BestPractices/**'
       - 'scripts/validate_examples.py'
+      - 'scripts/examples_baseline.json'
+      - '.github/workflows/validate-examples.yml'
   workflow_dispatch:
 
 jobs:
@@ -28,10 +30,68 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Tier 1 — structural checks
+        run: python3 scripts/validate_examples.py
 
+  compile:
+    runs-on: ubuntu-latest
+    needs: structural
+    # irishealth, NOT iris: several examples use EnsLib.HL7.*, which the plain IRIS
+    # community image does not carry. On the wrong image those classes fail for a reason
+    # that has nothing to do with the bank — preflight refuses to run rather than record
+    # that as a result.
+    env:
+      IRIS_HOST: localhost
+      IRIS_PORT: '52773'
+      IRIS_NAMESPACE: USER
+      IRIS_USER: _SYSTEM
+      IRIS_PASSWORD: SYS
+    steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
-      - name: Tier 1 — structural checks
-        run: python3 scripts/validate_examples.py
+      - name: Start IRIS for Health (community)
+        run: |
+          docker run -d --name iris \
+            -p 52773:52773 -p 1972:1972 \
+            intersystemsdc/irishealth-community:latest
+          echo "container started"
+
+      - name: Wait for the Atelier API
+        run: |
+          # IRIS takes 1-2 minutes to come up. Poll rather than sleep a fixed amount:
+          # a fixed sleep is either flaky or slow, and both get the job disabled.
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              -u "$IRIS_USER:$IRIS_PASSWORD" \
+              "http://localhost:$IRIS_PORT/api/atelier/v1/$IRIS_NAMESPACE" || true)
+            if [ "$code" = "200" ]; then
+              echo "ready after ${i}0s (HTTP $code)"
+              exit 0
+            fi
+            echo "  attempt $i: HTTP ${code:-none}"
+            sleep 10
+          done
+          echo "IRIS did not become ready in 10 minutes"
+          exit 1
+
+      - name: Preflight — is this target usable at all?
+        run: python3 scripts/validate_examples.py --preflight
+
+      - name: Tier 2 — compile every example
+        run: python3 scripts/validate_examples.py --compile
+
+      - name: IRIS logs (on failure)
+        if: failure()
+        run: |
+          echo "=== docker ps ==="
+          docker ps -a
+          echo "=== container logs (tail) ==="
+          docker logs --tail 200 iris || true
+          echo "=== messages.log ==="
+          docker exec iris sh -c 'tail -100 /usr/irissys/mgr/messages.log' || true

--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -57,27 +57,62 @@ jobs:
 
       - name: Start IRIS for Health (community)
         run: |
+          # Pinned, not :latest. The two are the same digest today (sha256:255ce9c0...),
+          # but a moving tag means this gate can break with no change to the repo — and
+          # 2026.1 is the version the baseline in scripts/examples_baseline.json was
+          # recorded against.
+          #
+          # IRIS_INIT=1 is load-bearing. Without it the entrypoint runs iris-after-start,
+          # which on this build dies in the image's own python glue:
+          #     [ERROR] Cannot call an iris.package wrapper ... Given name was: dbapi.connect
+          #     [ERROR] Command "/docker-entrypoint.sh iris-after-start " exited with status 256
+          #     [FATAL] Error executing post-startup command
+          # IRIS then shuts down cleanly ~12s after starting and the container exits 1, so
+          # every readiness probe sees HTTP 000. Setting IRIS_INIT skips that whole block
+          # (the entrypoint's own "Already initialized, skipping" path). The cost is that
+          # docker_setup_username is skipped too, which is why the password step below
+          # exists. Reproduced locally in 10s; do not remove without re-testing.
           docker run -d --name iris \
+            -e IRIS_INIT=1 \
             -p 52773:52773 -p 1972:1972 \
-            intersystemsdc/irishealth-community:latest
+            intersystemsdc/irishealth-community:2026.1
           echo "container started"
 
-      - name: Wait for the Atelier API
+      - name: Wait for the web server
         run: |
-          # IRIS takes 1-2 minutes to come up. Poll rather than sleep a fixed amount:
-          # a fixed sleep is either flaky or slow, and both get the job disabled.
+          # Poll rather than sleep a fixed amount: a fixed sleep is either flaky or slow,
+          # and both get a job disabled. Any HTTP response means IRIS is serving — 401 is
+          # expected here and is handled by the next step.
           for i in $(seq 1 60); do
             code=$(curl -s -o /dev/null -w '%{http_code}' \
               -u "$IRIS_USER:$IRIS_PASSWORD" \
               "http://localhost:$IRIS_PORT/api/atelier/v1/$IRIS_NAMESPACE" || true)
-            if [ "$code" = "200" ]; then
-              echo "ready after ${i}0s (HTTP $code)"
+            if [ "$code" != "000" ]; then
+              echo "web server answering after $((i*5))s (HTTP $code)"
               exit 0
             fi
-            echo "  attempt $i: HTTP ${code:-none}"
-            sleep 10
+            [ $((i % 6)) -eq 0 ] && echo "  ${i}: still no response"
+            sleep 5
           done
-          echo "IRIS did not become ready in 10 minutes"
+          echo "IRIS never answered in 5 minutes"
+          docker logs --tail 50 iris || true
+          exit 1
+
+      - name: Enable the default credentials
+        run: |
+          # Skipping iris-after-start also skipped docker_setup_username, so _SYSTEM's
+          # password is still flagged expired and every Atelier call returns 401.
+          docker exec iris iris session IRIS -U %SYS \
+            '##class(Security.Users).UnExpireUserPasswords("*")'
+          for i in $(seq 1 10); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              -u "$IRIS_USER:$IRIS_PASSWORD" \
+              "http://localhost:$IRIS_PORT/api/atelier/v1/$IRIS_NAMESPACE" || true)
+            if [ "$code" = "200" ]; then echo "authenticated (HTTP 200)"; exit 0; fi
+            echo "  attempt $i: HTTP $code"
+            sleep 3
+          done
+          echo "credentials still rejected"
           exit 1
 
       - name: Preflight — is this target usable at all?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,11 @@ sibling skill for each task. Always load `iris-interop-skills:tdd` as a companio
   name or path — a bare `Skill("messages")` errors with "Unknown skill".
 - `agents/*.md` — four bundled subagents (`interop-builder`, `deploy-smoke-test`,
   `introspect-dont-guess`, `conformance-reviewer`) that auto-register on install. MCP-server-agnostic (no server pinned).
-- `hooks/` — eight hooks auto-enabled via `plugin.json`: a SessionStart conventions bootstrap,
-  two blocking PreToolUse gates (conformance gate, src-before-iris), and five PostToolUse guards
-  (silent-execute guard, TDD enforcement, conformance pre-scan, docker-detect, tdd-first-green).
+- `hooks/` — nine hooks auto-registered via `hooks/hooks.json`: a SessionStart conventions
+  bootstrap, two blocking PreToolUse gates (conformance gate, src-before-iris), five PostToolUse
+  guards (silent-execute guard, TDD enforcement, conformance pre-scan, docker-detect,
+  tdd-first-green), and one blocking **Stop** gate (conformance-stop-gate) that enforces
+  "before declaring done" — see #96 for why an advisory nudge was worth 0 invocations in 206 runs.
 - **Required user setting:** raise the skill-listing budget (`skillListingBudgetFraction: 0.03`,
   `skillListingMaxDescChars: 2048`) in `~/.claude/settings.json` so `interop`/`tdd` don't get evicted.
 - `BestPractices/` — the worked-example bank the skills cite:

--- a/hooks/conformance-stop-gate.sh
+++ b/hooks/conformance-stop-gate.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Stop gate (iris-interop-skills) — the enforcement point for "before declaring done".
+# Blocks at most once per session: when classes were put into IRIS but never saved to disk
+# (CR-12), or when the conformance pass never ran. Unlike the other wrappers this one CAN
+# block, by design — see hooks/conformance_stop_gate.py and issue #96.
+# Thin wrapper: exec the .py so the hook JSON on stdin reaches Python. Resolves the
+# interpreter as python3 -> python -> py (Windows has no real `python3`, only a Store stub
+# that must be rejected); no-op if none is on PATH, so a machine without Python is never
+# gated by a hook it cannot run.
+PY=
+for _cand in python3 python py; do
+    _path=$(command -v "$_cand" 2>/dev/null) || continue
+    # Being on PATH is not the same as working. Windows ships a 0-byte Microsoft Store
+    # stub named python3.exe in %LOCALAPPDATA%\Microsoft\WindowsApps: `command -v` finds
+    # it, exec'ing it prints "Python was not found" and exits non-zero. Taking the first
+    # name that resolves made every hook fail on a machine that had a perfectly good
+    # python.exe one PATH entry away. Run the candidate before trusting it.
+    "$_path" -c '' >/dev/null 2>&1 || continue
+    PY=$_path
+    break
+done
+[ -n "$PY" ] || exit 0
+DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "$PY" "$DIR/conformance_stop_gate.py"

--- a/hooks/conformance_stop_gate.py
+++ b/hooks/conformance_stop_gate.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Stop gate: "before declaring done" needs a point at which done is declared.
+
+The plugin specifies a final compliance pass, defines twelve criteria for it, and tells the
+model to run it before declaring the work finished. Measured over 206 runs that produced
+authored `.cls`, the `conformance-reviewer` agent was spawned **0 times** — while
+`interop-builder`, whose instruction lives in the SessionStart hook, was spawned 79 times.
+The two instructions differ only in where they live (issue #96).
+
+The registered events were SessionStart, PreToolUse x2 and PostToolUse x4. There was no
+`Stop` hook, so "before declaring done" had no enforcement point at all: the model decided
+it was finished, stopped, and nothing ran. An advisory PostToolUse nudge is empirically
+worth 0 invocations in 206 runs.
+
+This hook is that missing point. It fires once, at the moment the model would stop.
+
+TWO CHECKS, DELIBERATELY DIFFERENT IN KIND
+------------------------------------------
+1. **Orphaned classes (CR-12), mechanical.** Every class this session wrote into IRIS with
+   `iris_doc(mode=put)` must also exist on disk. This needs no model judgement and no IRIS
+   connection — the transcript records what was put, and the filesystem is right here.
+
+   This closes a real gap in the PreToolUse gate rather than duplicating it.
+   `src_before_iris.py` returns early when the project has no `src/` tree at all ("a scratch
+   namespace with no source tree is none of this hook's business"). That is defensible per
+   call and fails open exactly when the loss is total: a run that never writes a file has no
+   source tree, so every put is permitted, and it ends with the namespace holding the only
+   copy. 16 runs in the corpus finished with no `.cls` on disk; 12 of them scored as passes,
+   one at 96.45. A Stop hook sees the whole session, so it can tell "scratch namespace, no
+   authoring" from "authored a production and saved none of it".
+
+2. **Conformance pass not run, behavioural.** If the session authored interop classes and
+   never invoked the reviewer, say so once. This one is a nudge with teeth rather than a
+   proof of error, so it blocks a single time and then gets out of the way.
+
+Both respect `stop_hook_active`, so the model is interrupted at most once per session and
+can always proceed after answering. A gate that cannot be satisfied is a gate that gets
+disabled.
+
+NOT MEASURED. That 0/206 is measured; whether this moves it is not, and cannot be from the
+skills session — it needs an eval pass (issue #102). Check (1) does not depend on model
+behaviour and so cannot regress to zero; check (2) might.
+"""
+import sys, json, os, re
+
+# Generated in IRIS by design, exported afterwards — never hand-authored, so never orphans.
+GENERATED = re.compile(r"(?:^|\.)(?:WSC|SOAPENC)\.|\.Record$|\.Record\.cls$", re.I)
+
+SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv", ".idea", ".vscode"}
+
+REVIEWER_AGENT = "conformance-reviewer"
+REVIEW_SKILL = "conformance-review"
+
+
+def project_root(data):
+    return data.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
+
+
+def cls_files(root):
+    """Every .cls path under the project, as forward-slash strings.
+
+    os.walk rather than glob('**') on purpose: glob silently skips dot-directories, so a
+    class staged under one reads as missing and the gate fires on a file that is right
+    there. That exact bug cost a debugging cycle earlier (#95).
+    """
+    out = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if fn.lower().endswith(".cls"):
+                out.append(os.path.join(dirpath, fn).replace("\\", "/"))
+    return out
+
+
+def find_orphans(root, classes):
+    """Classes with no file anywhere under the project.
+
+    Accepts the Atelier nested layout the `interop` skill mandates (src/Pkg/BO/Name.cls)
+    and, tolerantly, the legacy flat-dotted form (Pkg.BO.Name.cls).
+    """
+    paths = cls_files(root)
+    orphans = []
+    for cls in sorted(classes):
+        nested = "/" + cls.replace(".", "/") + ".cls"
+        flat = "/" + cls + ".cls"
+        if not any(p.endswith(nested) or p.endswith(flat) for p in paths):
+            orphans.append(cls)
+    return orphans
+
+
+def scan_transcript(path):
+    """Return (classes put into IRIS this session, whether a conformance pass ran).
+
+    Matches the JSON keys of genuine tool invocations, never prose: the router's own text
+    contains the literal string `Skill(iris-interop-skills:conformance-review)`, so it
+    appears in 98.4% of transcripts as loaded context. Counting that as evidence of a
+    review is the trap that made this look fine for 206 runs.
+    """
+    put, reviewed = set(), False
+    try:
+        fh = open(path, encoding="utf-8", errors="replace")
+    except OSError:
+        return put, True  # cannot read the transcript -> never block on a hook's blind spot
+
+    with fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            msg = rec.get("message") or {}
+            content = msg.get("content")
+            if not isinstance(content, list):
+                continue
+            for block in content:
+                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                    continue
+                tool = str(block.get("name") or "")
+                inp = block.get("input") or {}
+                if not isinstance(inp, dict):
+                    continue
+
+                if REVIEWER_AGENT in str(inp.get("subagent_type") or ""):
+                    reviewed = True
+                if REVIEW_SKILL in str(inp.get("skill") or ""):
+                    reviewed = True
+
+                if "iris_doc" in tool and inp.get("mode") == "put":
+                    name = str(inp.get("name") or "").strip()
+                    content_str = inp.get("content")
+                    if not name or not isinstance(content_str, str) or not content_str.strip():
+                        continue
+                    if GENERATED.search(name):
+                        continue
+                    put.add(re.sub(r"\.cls$", "", name, flags=re.I))
+    return put, reviewed
+
+
+def block(reason):
+    print(json.dumps({"decision": "block", "reason": reason}))
+    sys.exit(0)
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return  # never block on a hook bug
+
+    if data.get("stop_hook_active"):
+        return  # already interrupted once this session; say it once, not in a loop
+
+    transcript = data.get("transcript_path")
+    if not transcript:
+        return
+
+    put, reviewed = scan_transcript(transcript)
+    if not put:
+        return  # this session authored no interop classes; nothing to gate
+
+    root = project_root(data)
+    orphans = find_orphans(root, put)
+
+    if orphans:
+        listed = "\n".join(
+            "  - {}   ->  write it to src/{}.cls".format(c, c.replace(".", "/"))
+            for c in orphans[:15]
+        )
+        more = "\n  ... and {} more".format(len(orphans) - 15) if len(orphans) > 15 else ""
+        block(
+            "CR-12 — {} of the {} class(es) this session wrote into IRIS exist ONLY in the "
+            "namespace:\n\n{}{}\n\n"
+            "The namespace is not version-controlled, not reviewable, and does not survive the "
+            "instance, so this work is already lost — it just has not been noticed yet. Write "
+            "each class to disk with the same content that is in IRIS, then stop.\n\n"
+            "(Measured: 16 runs finished with no .cls on disk at all and 12 of them scored as "
+            "passes, one at 96.45 — ground truth is read from the namespace, so saving nothing "
+            "still grades green.)".format(len(orphans), len(put), listed, more)
+        )
+
+    if not reviewed:
+        block(
+            "The conformance pass has not run. This session authored {} interop class(es) and "
+            "every one is on disk, but nothing has checked them against the twelve criteria.\n\n"
+            "Run it now:\n"
+            "  Agent(subagent_type=\"iris-interop-skills:conformance-reviewer\")\n"
+            "    — the full pass; re-verifies tests through the real iris_test rather than "
+            "trusting a self-graded [SqlProc], which is CR-7.\n"
+            "  or Skill(iris-interop-skills:conformance-review) to review inline.\n\n"
+            "If the criteria genuinely do not apply here, say so and stop again — this fires "
+            "once per session, not in a loop.".format(len(put))
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/conformance_stop_gate.py
+++ b/hooks/conformance_stop_gate.py
@@ -56,36 +56,53 @@ def project_root(data):
     return data.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
 
 
-def cls_files(root):
-    """Every .cls path under the project, as forward-slash strings.
+# A .cls file declares its class; a .cls.xml export names it in an attribute.
+CLASS_DECL = re.compile(r"^[ \t]*Class[ \t]+([A-Za-z0-9_.%]+)", re.M)
+XML_DECL = re.compile(r"<Class\s+name=[\"\']([A-Za-z0-9_.%]+)[\"\']", re.I)
 
-    os.walk rather than glob('**') on purpose: glob silently skips dot-directories, so a
-    class staged under one reads as missing and the gate fires on a file that is right
-    there. That exact bug cost a debugging cycle earlier (#95).
+
+def classes_on_disk(root):
+    """Every class name actually DEFINED by a file under the project.
+
+    Matching on filename is the obvious implementation and it is wrong. This plugin's own
+    example bank names files by topic — `dtl-order-to-vendor.cls` defines
+    `Example.DT.OrderToVendor` — and a path-only check calls every one of them missing.
+    Tested against a real session transcript before this was fixed: 25 classes put into
+    IRIS, all 25 on disk, all 25 reported as orphans. A gate that is wrong 25 times out of
+    25 on a normal workflow does not get obeyed, it gets removed.
+
+    So presence is decided by content. The conventional path is still used, but only to
+    tell the model WHERE to write a class that genuinely is missing.
+
+    os.walk rather than glob('**'): glob silently skips dot-directories, so a class staged
+    under one reads as missing (#95 cost a cycle to that).
     """
-    out = []
+    found = set()
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
         for fn in filenames:
-            if fn.lower().endswith(".cls"):
-                out.append(os.path.join(dirpath, fn).replace("\\", "/"))
-    return out
+            low = fn.lower()
+            if not (low.endswith(".cls") or low.endswith(".cls.xml") or low.endswith(".xml")):
+                continue
+            path = os.path.join(dirpath, fn)
+            try:
+                with open(path, encoding="utf-8", errors="replace") as fh:
+                    text = fh.read()
+            except OSError:
+                continue
+            found.update(CLASS_DECL.findall(text))
+            found.update(XML_DECL.findall(text))
+            # a file named for its class counts even if the body cannot be parsed
+            base = fn[:-4] if low.endswith(".cls") else None
+            if base and "." in base:
+                found.add(base)
+    return found
 
 
 def find_orphans(root, classes):
-    """Classes with no file anywhere under the project.
-
-    Accepts the Atelier nested layout the `interop` skill mandates (src/Pkg/BO/Name.cls)
-    and, tolerantly, the legacy flat-dotted form (Pkg.BO.Name.cls).
-    """
-    paths = cls_files(root)
-    orphans = []
-    for cls in sorted(classes):
-        nested = "/" + cls.replace(".", "/") + ".cls"
-        flat = "/" + cls + ".cls"
-        if not any(p.endswith(nested) or p.endswith(flat) for p in paths):
-            orphans.append(cls)
-    return orphans
+    """Classes this session put into IRIS that no file under the project defines."""
+    on_disk = classes_on_disk(root)
+    return [c for c in sorted(classes) if c not in on_disk]
 
 
 def scan_transcript(path):
@@ -125,15 +142,33 @@ def scan_transcript(path):
                 if REVIEW_SKILL in str(inp.get("skill") or ""):
                     reviewed = True
 
-                if "iris_doc" in tool and inp.get("mode") == "put":
+                if "iris_doc" not in tool:
+                    continue
+                mode = inp.get("mode")
+
+                if mode == "put":
                     name = str(inp.get("name") or "").strip()
                     content_str = inp.get("content")
                     if not name or not isinstance(content_str, str) or not content_str.strip():
                         continue
                     if GENERATED.search(name):
                         continue
-                    put.add(re.sub(r"\.cls$", "", name, flags=re.I))
+                    put.add(strip_cls(name))
+
+                elif mode == "delete":
+                    # Staging scratch classes and deleting them afterwards is a legitimate
+                    # workflow — it is how the example bank is compile-checked. Without
+                    # this, cleaning up correctly looks identical to abandoning work in the
+                    # namespace, and the gate fires on the careful case.
+                    for n in ([inp.get("name")] + list(inp.get("names") or [])):
+                        if isinstance(n, str) and n.strip():
+                            put.discard(strip_cls(n.strip()))
+
     return put, reviewed
+
+
+def strip_cls(name):
+    return re.sub(r"\.cls$", "", name, flags=re.I)
 
 
 def block(reason):

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -71,6 +71,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/conformance-stop-gate.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/interop_bootstrap.py
+++ b/hooks/interop_bootstrap.py
@@ -32,7 +32,12 @@ MSG = (
     "namespace. Write src/<Pkg>/<Tipo>/<Name>.cls FIRST, then iris_doc(mode=put) the same "
     "content; a PreToolUse gate BLOCKS a put whose class has no file on disk. Classes generated "
     "by IRIS (RecordMap .Record, SOAP WSC.*) are the exception — export them with "
-    "iris_doc(mode=get) right after generating."
+    "iris_doc(mode=get) right after generating; "
+    "(8) BEFORE DECLARING DONE, run the conformance pass — hand the finished production to "
+    "Agent(subagent_type=\"iris-interop-skills:conformance-reviewer\"), or load "
+    "Skill(iris-interop-skills:conformance-review) and check the twelve criteria inline. A Stop "
+    "hook enforces this: it blocks once if any class you put into IRIS has no file on disk "
+    "(CR-12), or if the pass never ran."
 )
 
 

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -40,6 +40,7 @@ import os
 import re
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -205,7 +206,9 @@ class Atelier:
         pwd = os.environ.get("IRIS_PASSWORD", "SYS")
         token = base64.b64encode(f"{user}:{pwd}".encode()).decode()
         self.auth = f"Basic {token}"
-        self.base = f"http://{self.host}:{self.port}/api/atelier/v1/{self.ns}"
+        # The namespace goes in the URL path, so it must be encoded: %SYS and any namespace
+        # with a % in it otherwise returns HTTP 400 and gets misreported as "unreachable".
+        self.base = f"http://{self.host}:{self.port}/api/atelier/v1/{urllib.parse.quote(self.ns, safe='')}"
 
     def _call(self, method: str, path: str, body=None):
         data = json.dumps(body).encode() if body is not None else None
@@ -224,6 +227,68 @@ class Atelier:
 
     def delete(self, name: str):
         return self._call("DELETE", f"/doc/{name}")
+
+    def query(self, sql: str):
+        return self._call("POST", "/action/query", {"query": sql, "parameters": []})
+
+
+def preflight() -> bool:
+    """Prove the environment is usable BEFORE compiling anything.
+
+    Without this, a misconfigured target produces a uniformly red run that reads as "the
+    examples are broken" when it actually means "this IRIS has no Interoperability". That is
+    a worse outcome than no CI check at all, because it trains people to ignore the result.
+    Each failure below names which of the two it is.
+    """
+    print("Preflight\n")
+    iris = Atelier()
+    print(f"  target {iris.base}")
+
+    try:
+        ver = iris._call("GET", "")
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError) as exc:
+        print(f"  FAIL  cannot reach IRIS: {exc}")
+        print("        ENVIRONMENT problem, not an example problem.")
+        print("        Check IRIS_HOST / IRIS_PORT / IRIS_USER / IRIS_PASSWORD.")
+        return False
+    content = (ver.get("result") or {}).get("content") or {}
+    dbs = ", ".join(d.get("name", "?") for d in (content.get("db") or [])[:6])
+    print(f"  ok    reachable — namespace {content.get('name', iris.ns)} over [{dbs}]")
+
+    try:
+        rows = (iris.query(
+            "SELECT COUNT(*) AS n FROM %Dictionary.CompiledClass WHERE Name = 'Ens.Director'"
+        ).get("result") or {}).get("content") or []
+        has_ens = rows and int(list(rows[0].values())[0]) > 0
+    except Exception as exc:
+        print(f"  FAIL  could not query the dictionary in namespace {iris.ns}: {exc}")
+        print("        ENVIRONMENT problem, not an example problem.")
+        return False
+
+    if not has_ens:
+        print(f"  FAIL  namespace {iris.ns} has no Ens.Director — Interoperability is not enabled")
+        print("        ENVIRONMENT problem, not an example problem. Every Ens.* example would")
+        print("        fail for the same reason and the run would say nothing about the bank.")
+        return False
+    print(f"  ok    namespace {iris.ns} is Interoperability-enabled")
+
+    try:
+        rows = (iris.query(
+            "SELECT COUNT(*) AS n FROM %Dictionary.CompiledClass WHERE Name = 'EnsLib.HL7.Message'"
+        ).get("result") or {}).get("content") or []
+        has_hl7 = rows and int(list(rows[0].values())[0]) > 0
+    except Exception:
+        has_hl7 = False
+
+    if not has_hl7:
+        print("  FAIL  EnsLib.HL7.Message is absent — this is IRIS, not IRIS for Health")
+        print("        ENVIRONMENT problem. Several examples legitimately need the HL7 library;")
+        print("        use an irishealth image rather than recording them as failures.")
+        return False
+    print("  ok    HL7 library present")
+
+    print("\nPreflight: environment is usable\n")
+    return True
 
 
 def parse_failures(result: dict, known: set[str]) -> dict[str, str]:
@@ -349,6 +414,8 @@ def update_baseline() -> None:
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--compile", action="store_true", help="also run tier 2 against a live IRIS")
+    ap.add_argument("--preflight", action="store_true",
+                    help="only check that the IRIS target is usable, then exit")
     ap.add_argument("--update-baseline", action="store_true", help="re-record the expected-clean list")
     args = ap.parse_args()
 
@@ -356,9 +423,14 @@ def main() -> int:
         update_baseline()
         return 0
 
+    if args.preflight:
+        return 0 if preflight() else 1
+
     ok = tier1()
     if args.compile:
-        ok = tier2() and ok
+        # A failed preflight means the environment is wrong, not the bank. Say which,
+        # and do not stage 34 classes into an instance that cannot compile them.
+        ok = (preflight() and tier2()) and ok
     return 0 if ok else 1
 
 

--- a/skills/conformance-review/SKILL.md
+++ b/skills/conformance-review/SKILL.md
@@ -11,6 +11,15 @@ description: Review an already-built IRIS Interoperability production against th
 > build skills alone; they do not carry the criteria, and a review without CR-1…CR-12 misses the
 > checks this plugin exists to make.
 
+> **A Stop hook enforces this pass.** When a session has written classes into IRIS, it blocks
+> once at the moment the model would stop: hard on **CR-12** (any class put into IRIS with no
+> file on disk — mechanical, no judgement involved), and once on "the conformance pass never
+> ran". Answer it and stop again; it fires at most once per session. It exists because this
+> instruction previously had *no* enforcement point — measured over 206 runs that produced
+> authored `.cls`, the `conformance-reviewer` agent was spawned **0 times**, while
+> `interop-builder`, whose instruction lives in the SessionStart hook, was spawned 79. The two
+> differed only in where they lived (#96).
+
 A built production can **compile and "pass tests"** and still be non-idiomatic. This skill defines the
 criteria a finished interop build is checked against, and the **review workflow**: surface findings →
 propose a scoped remediation plan → apply only the unambiguous fixes, with the user's OK. It does **not**


### PR DESCRIPTION
Two issues, both about the same thing: a check that exists but never runs.

## #96 — the conformance pass had no enforcement point

The plugin specified a final compliance pass, defined twelve criteria, and said to run it "before declaring done". Over 206 runs that produced authored `.cls`, the `conformance-reviewer` agent was spawned **0 times** — while `interop-builder`, whose instruction lives in the SessionStart hook, was spawned **79**. The two differ only in *where they live*.

Registered events were SessionStart, PreToolUse ×2, PostToolUse ×4. **There was no `Stop` hook**, so "before declaring done" had no moment at which it could be checked.

### New: `hooks/conformance_stop_gate.py`

Blocks at most once per session, on two checks of deliberately different kinds:

**1. CR-12 — mechanical.** Every class this session put into IRIS must exist on disk. Read from the transcript, so no model judgement and no IRIS connection needed.

This closes a gap rather than duplicating `src_before_iris.py`. That gate returns early when the project has no `src/` tree — defensible per call, and **it fails open exactly when the loss is total**: a run that never writes a file has no source tree, so every put is permitted, and it ends with the namespace holding the only copy. 16 runs finished with no `.cls` on disk; 12 scored as passes, one at 96.45. A `Stop` hook sees the whole session, so it can tell "scratch namespace" from "authored a production and saved none of it".

**2. Conformance pass not run — behavioural.** Blocks once, then gets out of the way.

Both respect `stop_hook_active`, so the model is interrupted at most once and can always proceed after answering. A gate that cannot be satisfied is a gate that gets disabled.

Evidence matching is on **JSON keys of real tool invocations, never prose** — the router's own text contains the literal string `Skill(iris-interop-skills:conformance-review)` and appears in 98.4% of transcripts as loaded context. Counting that as a review is the trap that made this look fine for 206 runs.

**8/8 negative controls**, including that router prose is *not* accepted as evidence and that `stop_hook_active` suppresses a second block.

Also: SessionStart injection now names the conformance pass as convention (8) — the one placement with a demonstrated 79-invocation track record.

**Not done, deliberately:** suggestion (3), escalating `conformance_prescan.py` from advisory to blocking on P1. Its detection is heuristic, and turning a heuristic into a blocker without calibrating false positives is how a gate earns a reputation for crying wolf and gets disabled. Wants its own pass.

## #101 — tier 2 now runs in CI

Adds a `compile` job on `intersystemsdc/irishealth-community`, gated behind a new `--preflight`.

**The preflight is the point.** A misconfigured target produces a uniformly red run that reads as "the examples are broken" when it means "this IRIS has no Interoperability" — worse than no check, because it trains people to ignore the result. Preflight proves the environment first and names which kind of failure it is:

| Symptom | Verdict |
|---|---|
| unreachable / bad credentials | ENVIRONMENT — names the env vars to check |
| namespace has no `Ens.Director` | ENVIRONMENT — Interoperability not enabled |
| `EnsLib.HL7.Message` absent | ENVIRONMENT — this is IRIS, not IRIS for Health |

That last one is why the job pins **irishealth**. All four paths verified by negative control against the live dev instance; each exits 1 and names the right cause.

Found by those controls and fixed: the namespace was not URL-encoded, so `%SYS` returned HTTP 400 and was misreported as "cannot reach IRIS" instead of "Interoperability not enabled".

## Verification status

- Tier 1 + tier 2 green locally: **34/34 compiling**, cleanup verified, 0 classes left in IRIS.
- The `compile` job itself is **unproven until this PR's CI runs** — that is what the PR is for. If `USER` on the community image turns out not to be Interop-enabled, preflight will say so plainly rather than producing 34 misleading failures.
- **#96's effect is unmeasured.** The 0/206 is measured; whether this moves it needs an eval pass (#102). Check (1) does not depend on model behaviour and cannot regress to zero; check (2) might.

Closes #96
Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)