### PR TITLE
release: 1.8.1 — the conformance pass gets a forcing function, and CI compiles the bank

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.0"
+    "version": "1.8.1"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Two closed issues, both about a check that existed but never ran.

## #96 — the conformance pass had no enforcement point

Over 206 runs that produced authored `.cls`, the `conformance-reviewer` agent was spawned **0 times** — while `interop-builder`, whose instruction lives in the SessionStart hook, was spawned **79**. The two differed only in *where they lived*. Registered events were SessionStart, PreToolUse ×2, PostToolUse ×4: there was no `Stop` hook, so "before declaring done" had no moment at which it could be checked.

A ninth hook supplies it. `conformance_stop_gate.py` blocks at most once per session:

- **CR-12, mechanical** — any class put into IRIS with no file on disk. Read from the transcript, so no model judgement and no IRIS connection.
- **Conformance pass not run, behavioural** — blocks once, then gets out of the way.

Both respect `stop_hook_active`, so the model is interrupted once and can always proceed after answering.

> ⚠️ **User-visible behaviour change.** This is the plugin's first hook that can block at `Stop`. A session that writes classes into IRIS without saving them to disk, or that never runs the conformance pass, is interrupted once before it can finish. Worth knowing this is arguably more than a patch-level change.

## #101 — tier 2 runs in CI

Every push touching `BestPractices/` now compiles all 34 example classes against a real IRIS for Health container and fails the build on regression:

```
web server answering after 20s (HTTP 401)
authenticated (HTTP 200)
ok  namespace USER is Interoperability-enabled
ok  HL7 library present
staging 34 classes → compiled clean : 34 / 34 → cleanup : 34 deleted
```

Gated behind a preflight that separates "this environment is wrong" from "these examples are wrong" — a uniformly red run meaning the former is worse than no check, because it trains people to ignore the result.

Manifest: 20 skills / **9 hooks** / 4 agents / 37 example artefacts (34 `.cls`, 34/34 compiling in CI).

## Two things worth recording

**The Stop gate was wrong 25 times out of 25** when first run against a real transcript, despite 8 synthetic controls passing — the controls were written to the same wrong model as the code. Fixed by matching on what a file *defines* rather than its filename, and by letting `iris_doc(mode=delete)` cancel a put. Controls now 11/11.

**The CI failure was in the vendor image**, not the harness: `intersystemsdc/irishealth-community` dies in its own Python glue during `iris-after-start` and shuts IRIS down 12s after boot. Diagnosed locally at 10s per attempt instead of 10min per CI round trip. `IRIS_INIT=1` and the password step both look arbitrary and are both load-bearing; the exact error text sits in the workflow beside them.

## Not claimed

- **#96's effect is unmeasured.** The 0/206 is measured; whether the hook moves it needs the eval pass in #102. Check (1) cannot regress to zero since it does not depend on model behaviour; check (2) might.
- The hook is **Claude Code only**, so it does nothing for the opencode and codex runs in that corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)