### PR TITLE
release: 1.8.2 — the stop gate can now see the work it was built to check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.1"
+    "version": "1.8.2"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Patch release, and a **correction to 1.8.1** rather than an addition.

## What 1.8.1 got wrong

It shipped a Stop-hook forcing function for the conformance pass. The first eval pass measured **2 firings in 11 sonnet runs, 0 in 11 haiku**, against a prediction of essentially every run.

**Root cause:** a Stop hook is handed the MAIN session's transcript, and a subagent's tool calls are not in it. Confirmed on a real session — every main-transcript entry carries `isSidechain: False`, and **33 classes put into IRIS by subagents were invisible to the gate**.

That made 1.8.1's gate blind on **exactly the path this plugin recommends**. The SessionStart hook says *"hand the whole component to the interop-builder agent"*, and `interop-builder` is the most-spawned agent in the corpus at 79 spawns. The gate could only fire when the main session authored something itself — precisely the shape that was measured.

## What 1.8.2 changes

Walks the main transcript **plus every subagent transcript** for the session. Verified on the real session: **15 transcripts scanned where 1.8.1 read 1**, and the gate blocks where it was silent.

Adds env-gated diagnostics (`IRIS_INTEROP_HOOK_DEBUG`). Every exit path was silent — an allowing hook writes no attachment, so "never invoked" and "invoked, allowed" were indistinguishable from outside. That cost two rounds of guessing. Unset, it writes nothing.

## Verification

- 34/34 examples compile against live IRIS 2026.1, cleanup verified
- 8/8 hook controls, including that router prose is not accepted as evidence and that `stop_hook_active` suppresses a second block
- Manifest: 20 skills / 9 hooks / 4 agents / 37 example artefacts

## Not claimed

**That the gate is now effective.** It is now *reachable* on the recommended path, which it demonstrably was not. Whether reachable becomes complied-with needs another eval pass.

The escape-hatch wording in the block text remains a live suspect for the **compliance** branch and is unchanged — at 2 firings and 1 compliance it is not yet measurable.

⚠️ Anyone pinning **1.8.1** for evaluation should know it measured a hook that could not reach its own trigger on the common path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)