### PR TITLE
release: 1.8.3 — the source-of-truth gate no longer disables itself on a new project

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.2"
+    "version": "1.8.3"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Patch release, one fix (#107).

`src_before_iris.py` asked whether the project keeps sources on disk and returned without checking when the answer was no. The gate could therefore only fire in a session that had **already acquired the habit it exists to instil** — a greenfield workspace, which is every first put of every new project, was waved through while the SessionStart bootstrap advertised it as unconditional. `mkdir src`, which creates nothing, was the difference between off and on.

A class named `<Pkg>.<Tipo>.<Name>` is now gated **always**. Everything else keeps the original scratch exemption. **Additive** — every case that denied before still denies.

Also: `on_disk` used `glob("**")`, which silently skips dot-directories, so a class staged under one read as missing and got a wrong DENY. Now `os.walk` — a false-positive fix only.

## Pre-release gates

| gate | result |
|---|---|
| example bank, live IRIS 2026.1 | **34/34 compile**, cleanup verified |
| `src_before_iris` controls | **7/7** |
| `conformance_stop_gate` controls | **8/8** |

Manifest: 20 skills / 9 hooks / 4 agents / 37 example artefacts.

## Scope, preserved from the issue

This was a **latent** hole found by code read and reproduction. The 24 corpus runs that compiled a class with no `.cls` on disk are **not** explained by it — the claude runs among them at ≥ 1.6.0 all had a `src/` directory, so the gate was live for every put they made. Something else is letting classes through, and it is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)