### PR TITLE
release: 1.8.4 — close the other routes into the class dictionary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.3"
+    "version": "1.8.4"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Patch release, one fix (#110).

`$SYSTEM.OBJ` was never the only way to make a class from ObjectScript, and it was the only one gated. Reproduced live on IRIS 2026.1 with **1.8.3 hooks active**:

```objectscript
##class(%Compiler.UDL.TextServices).SetTextFromStream("APP","Probe.BO.GateBypass.cls",src)
→ exists in dictionary: 1     both gates silent
```

Now gated, calibrated to mutations: `TextServices SetText*`, the `%Dictionary.*Definition` object API, and `set`/`kill`/`merge` on `^oddDEF`/`^oddCOM`.

## Also gated — and this came from review, not from me

**`^oddDEF`/`^oddCOM` reads.** The first cut allowed `$order` over the dictionary global as "legitimate introspection". It is not — that global is the undocumented internal representation, and reading it is the guessing `introspect-dont-guess` exists to prevent. I had mistaken *"it's a read, so it's harmless"* for *"it's a read, so it's correct."*

Verified before asserting an alternative: **58 persistent SQL-queryable `%Dictionary.*` classes and 129 predefined queries**, and both real corpus uses map straight across:

| hand-rolled | supported |
|---|---|
| `$Order(^oddDEF(name))` | `SELECT Name FROM %Dictionary.ClassDefinition` |
| `$ORDER(^oddDEF(cls,"p",param))` | `%Dictionary.CompiledProperty`, or `:Summary` |

Nothing is lost by forbidding it, which is what makes it safe to gate rather than merely discourage. The deny names the hierarchy: typed MCP tools → `%Dictionary` SQL → predefined queries.

## Verification

| gate | result |
|---|---|
| example bank, live IRIS 2026.1 | **34/34**, cleanup verified |
| conformance-gate controls | **10/10** |
| src-gate controls | **4/4** |
| replay vs 15 real corpus `iris_execute` calls | **15/15 blocked** (was 12/15) |

## Scope

A mechanism, not necessarily the whole explanation for the 24 corpus runs that compiled a class with no `.cls` on disk. Observed prevalence of the creation routes is **one run** — the live reproduction is the evidence, not the frequency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)