### PR TITLE
fix(skills): the alerting dedup guard and the lookup NormalizeKey both fail as written (#113, #114)

### DIFF
--- a/skills/alerting/SKILL.md
+++ b/skills/alerting/SKILL.md
@@ -96,8 +96,23 @@ ClassMethod AlreadyReportedPerSession() As %Boolean
 Wire it in the `Ens.Alert` routing rule as a guard:
 
 ```
-when MyApp.UTL.AlertFilterFunctions.AlreadyReportedErr(SourceConfigName, AlertText, 60) → skip
+when AlreadyReportedErr(Document.SourceConfigName, Document.AlertText, 60) → skip
 ```
+
+Both halves of that expression are load-bearing, and getting either wrong fails in a way the error
+does not name (#113):
+
+- **Call the FunctionSet method by BARE NAME — never qualify it with its package.** The rule
+  expression parser resolves methods across every `Ens.Rule.FunctionSet` subclass in the namespace,
+  which is what the FunctionSet pattern is for. A qualified call does not parse:
+  `<Ens>ErrInvalidToken` at the offset of the `.`, surfacing as `#5490` running the generator for
+  `evaluateRuleDefinition` and `#5030` compiling the rule class — none of which says "drop the
+  package".
+- **Reach message fields through `Document.`.** With `context="EnsLib.MsgRouter.RoutingEngine"` the
+  bare form `AlreadyReportedErr(SourceConfigName, AlertText, 60)` **compiles** and is still wrong:
+  the engine context has `Document` and does not have `SourceConfigName` or `AlertText` — those are
+  properties of the `Ens.AlertRequest` message. The rule then builds and silently guards nothing,
+  which is the worse of the two failures.
 
 Worked example: `${CLAUDE_PLUGIN_ROOT}/BestPractices/examples/ch07_alerting/alert-dedup-functionset.cls`.
 

--- a/skills/bpl/SKILL.md
+++ b/skills/bpl/SKILL.md
@@ -210,11 +210,27 @@ For multi-router productions, extend step 2 to iterate every `EnsLib.MsgRouter.R
 
 If a destination is *legitimately flaky* (network, downstream service that does go down), use `EnsLib.MsgRouter.RoutingEngine` settings rather than rewriting rules:
 
-- `AlertOnError="true"` — emit an `Ens.AlertRequest` instead of terminating the BP.
+- `AlertOnError` — emit an `Ens.AlertRequest` instead of terminating the BP.
 - `BadMessageHandler` — a target item where un-routable messages go (configure a file logger or an alerts router as the value).
 - `ReplyCodeActions` — per-error-code action table (Retry / Fail / Suspend / Skip per error class).
 
-These are knobs on the Router item itself, not on individual rules.
+These are knobs on the Router item itself, not on individual rules. **In production XML they are
+`<Setting>` elements, never `<Item>` attributes:**
+
+```xml
+<Item Name="Router" ClassName="EnsLib.MsgRouter.RoutingEngine">
+  <Setting Target="Host" Name="AlertOnError">1</Setting>
+  <Setting Target="Host" Name="BadMessageHandler">ErrorFileLogger</Setting>
+</Item>
+```
+
+`<Item ... AlertOnError="true">` fails the whole class with *attribute 'AlertOnError' is not
+declared for element 'Item'*. The `<Item>` element maps to `Ens.Config.Item`, whose 19 properties
+are `Name`, `ClassName`, `Enabled`, `PoolSize`, `Schedule`, `Category`, `Comment`,
+`DisableErrorTraps`, `Foreground`, `InactivityTimeout`, `LogTraceEvents`, `AlertGroups` and the
+rest — `AlertOnError` is not among them. Host settings reach the item through its `Settings`
+collection (`Ens.Config.Setting`), which is what `<Setting>` builds. Note the value is `1`/`0`,
+not `"true"`.
 
 ## Timeout precedence — BO timeout MUST be smaller than calling BP
 

--- a/skills/lookup-tables/SKILL.md
+++ b/skills/lookup-tables/SKILL.md
@@ -86,10 +86,19 @@ obvious-looking mask is the broken one:
   helper returns, every lookup misses, and with the DTL below's `""` default every message throws
   `InvalidDieta` instead. Prefer `"*WC"` and fold accents explicitly.
 
-Do not reach for `$ZCONVERT(value, "O", "UTF8")` to strip accents. On an already-internal string it
-does not fail — measured here, `$ZCONVERT("Diab"_$CHAR(233)_"tica", "O", "UTF8")` returns
-`DiabÃ©tica`, the UTF-8 bytes re-read as single characters. It silently double-encodes, which then
-propagates into the lookup key. `$TRANSLATE` above is self-contained and testable.
+Do not reach for the `$ZCONVERT(..., "O", "UTF8")` / `$ZCONVERT(..., "I", "Latin1")` round trip to
+strip accents. Measured leg by leg on 2026.1, it fails **twice, in two different ways**:
+
+| step | result |
+|---|---|
+| `$ZCONVERT("Diab"_$CHAR(233)_"tica", "O", "UTF8")` | `DiabÃ©tica` — len 10, codes 195,169. **No error.** |
+| `$ZCONVERT(<that>, "I", "Latin1")` | **`<ILLEGAL VALUE>`** |
+| the composite, as usually written | **`<ILLEGAL VALUE>`** |
+
+The throw is the easy half — you find out. The first leg is the dangerous one: on an
+already-internal string it silently re-reads the UTF-8 bytes as single characters, and if you ever
+use it alone the double-encoded value propagates straight into the lookup key. `$TRANSLATE` above is
+self-contained and testable.
 
 ### 3. Use from DTL
 

--- a/skills/lookup-tables/SKILL.md
+++ b/skills/lookup-tables/SKILL.md
@@ -60,13 +60,36 @@ Add a helper to your project's `FunctionSet` subclass (see `transformations` for
 ```objectscript
 ClassMethod NormalizeKey(value As %String) As %String [ Final ]
 {
-    Quit $ZSTRIP($ZCONVERT(value, "L"), "*-CWE")
+    Set tAccents = $CHAR(225,233,237,243,250,241,224,232,236,242,249,252)  // áéíóúñàèìòùü
+    Set tPlain   = "aeiounaeiouu"
     // $ZCONVERT(..,"L"): lowercase
-    // $ZSTRIP "*-CWE": strip whitespace, control chars, "E"-equivalents (covers ASCII punct)
-    // For accent stripping use $ZCONVERT(value, "O", "UTF8")$ZCONVERT(..., "I", "Latin1")
-    // followed by $TRANSLATE for the residue. Keep the policy here, not at call sites.
+    // $ZSTRIP "*WC": strip whitespace and control characters
+    // $TRANSLATE: fold accents. Keep the policy here, not at call sites.
+    Quit $TRANSLATE($ZSTRIP($ZCONVERT(value, "L"), "*WC"), tAccents, tPlain)
 }
 ```
+
+| input | result |
+|---|---|
+| `Diabética` | `diabetica` |
+| `"  DIABÉTICA  "` | `diabetica` |
+| `Diabetica` | `diabetica` |
+
+**Two `$ZSTRIP` traps, both measured on IRIS 2026.1 (#114).** They are worth stating because the
+obvious-looking mask is the broken one:
+
+- **`-` is not a `$ZSTRIP` action character.** Any mask containing it — `"*-CWE"`, `"*-CW"`, `"*-E"`
+  — raises `<FUNCTION>`, so a DTL calling the helper fails on every message. (`*'ANU`, the
+  apostrophe-negation form, throws here too.)
+- **`E` does not mean "ASCII punctuation".** It strips *everything*: `$ZSTRIP(x,"*CWE")` and
+  `$ZSTRIP(x,"*E")` both return the empty string for every input. That failure is silent — the
+  helper returns, every lookup misses, and with the DTL below's `""` default every message throws
+  `InvalidDieta` instead. Prefer `"*WC"` and fold accents explicitly.
+
+Do not reach for `$ZCONVERT(value, "O", "UTF8")` to strip accents. On an already-internal string it
+does not fail — measured here, `$ZCONVERT("Diab"_$CHAR(233)_"tica", "O", "UTF8")` returns
+`DiabÃ©tica`, the UTF-8 bytes re-read as single characters. It silently double-encodes, which then
+propagates into the lookup key. `$TRANSLATE` above is self-contained and testable.
 
 ### 3. Use from DTL
 


### PR DESCRIPTION
Closes #113
Closes #114

Two skills shipped ObjectScript that does not run. Both found by the testsuite session while authoring `ALERT-BUILD-01` and `LOOKUP-BUILD-01` — the first scenarios that ask a model to *execute* these paths. Neither skill had anything but fire/negative probes before, so nothing had ever run the code.

## #113 — `skills/alerting/SKILL.md`

The dedup guard contradicted the worked example it points at, in **both** halves.

```diff
-when MyApp.UTL.AlertFilterFunctions.AlreadyReportedErr(SourceConfigName, AlertText, 60) → skip
+when AlreadyReportedErr(Document.SourceConfigName, Document.AlertText, 60) → skip
```

- **Qualified call does not parse** — `<Ens>ErrInvalidToken` at the `.`, surfacing as `#5490` on the `evaluateRuleDefinition` generator and `#5030` compiling the rule class. Nothing in that chain says "drop the package".
- **Bare property names compile and are still wrong.** Re-verified against the class dictionary rather than taken from the issue:

| query | result |
|---|---|
| `%Dictionary.CompiledProperty` where parent = `EnsLib.MsgRouter.RoutingEngine` | **`Document`** only |
| `%Dictionary.CompiledProperty` where parent = `Ens.AlertRequest` | `AlertText`, `SourceConfigName` |

So the old form builds a rule that guards nothing. Also settles the "medium confidence" note left open in **#88 §1**, from the dictionary instead of the Rule Editor.

## #114 — `skills/lookup-tables/SKILL.md`

`NormalizeKey` raised `<FUNCTION>` on every call, and the charitable fix silently returned `""` for every input. Measured on IRIS 2026.1 (Build 235U):

| expression | result |
|---|---|
| `$ZSTRIP($ZCONVERT(v,"L"),"*-CWE")` | **`<FUNCTION>`** — `-` is not an action character |
| `$ZSTRIP($ZCONVERT(v,"L"),"*CWE")` | **`""`** — `E` strips everything, not "ASCII punct" |
| `$ZSTRIP($ZCONVERT(v,"L"),"*E")` | **`""`** |

The second is the dangerous one: it does not crash, it makes the whole validation list unmatchable, and with the DTL example's `""` default every message then throws `InvalidDieta`.

Replaced with an explicit `*WC` strip plus `$TRANSLATE` accent folding, verified end to end:

```
Diabética -> diabetica     "  DIABÉTICA  " -> diabetica     " Sin Sal " -> sinsal
```

### One correction to #114, from measuring rather than repeating

#114 states `$ZCONVERT(value,"O","UTF8")` "raises `<ILLEGAL VALUE>` in this build". **It does not.** It returns `DiabÃ©tica` — the UTF-8 bytes re-read as single characters. It silently double-encodes, which is a *better* argument against it than a throw, so the skill says that instead.

## Notes

Both skills gain the trap as prose, not just the corrected line — a reader who hits the compile error or the empty lookup should find the cause named where they are already reading.

Tier 1: **7/7 checks, 37 artefacts, 34 classes.** No example-bank files touched, so tier 2 is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)