### PR TITLE
release: 1.8.5 — three skills shipped ObjectScript that does not run

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.4"
+    "version": "1.8.5"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Patch release. **Three `SKILL.md` files only** — no hook, agent or example-bank change.

| fix | skill | failure |
|---|---|---|
| #113 | `alerting` | dedup guard contradicts its own example, in both halves — one does not parse, the other compiles and guards nothing |
| #114 | `lookup-tables` | `NormalizeKey` raises `<FUNCTION>`; the charitable reading returns `""` for every input |
| — | `bpl` | `AlertOnError` shown as an `<Item>` attribute; the whole class fails to compile |

## What unites them

Every one is code a reader is told to copy, and **none of it had ever been executed.** `lookup-tables` and `alerting` were among five skills carrying only fire/negative probes — nothing in the corpus had ever asked a model to *build* from them. The defects surfaced within minutes of the testsuite session authoring `ALERT-BUILD-01` and `LOOKUP-BUILD-01`, the first scenarios that execute these paths.

## Verified, not accepted

Everything re-measured here on IRIS 2026.1 Build 235U before committing:

- `EnsLib.MsgRouter.RoutingEngine` → **`Document` only**; `Ens.AlertRequest` → `AlertText`, `SourceConfigName`
- `*-CWE` → `<FUNCTION>` · `*CWE` → `""` · new form → `diabetica` / `diabetica` / `sinsal`
- `Ens.Config.Item` → 19 properties, `AlertOnError` not among them

### Two corrections from measuring rather than repeating a report

#114 said `$ZCONVERT(v,"O","UTF8")` raises `<ILLEGAL VALUE>`. Leg by leg it does not — it returns `DiabÃ©tica` (len 10, codes 195,169) with **no error**, and the throw is the *second* leg. My own first reading checked only leg one and concluded there was no throw. Each report was half right; the skill now carries both, because they fail differently and the silent one is the better argument against the round trip.

## Gates

- **34/34** examples compile on live IRIS, cleanup verified
- Tier 1 **7/7**
- Hooks unchanged and not re-gated — no hook file differs from 1.8.4

Manifest: **20 skills / 9 hooks / 4 agents / 37 example artefacts (34 .cls)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)