### PR TITLE
release: 1.8.6 — four skills that misroute or ship code that does not run

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.5"
+    "version": "1.8.6"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.5",
+      "version": "1.8.6",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Patch release. Four `SKILL.md` files — no hook, agent or example-bank change.

| # | skill | failure |
|---|---|---|
| #118 | `production-lifecycle` | `DriftReport` does not compile, walks `^oddCOM` (which 1.8.4 denies), and never reports the disk direction its prose promises |
| #119 | `lookup-tables` | the `&sql` warning names the wrong cause; the two typed lookup tools were absent from the section about loading lookups via MCP |
| #120 | `alerting`, `security` | trigger lists saturated with product-agnostic words — fires on a pure Prometheus prompt, 12/12 on codex |
| — | `transformations` | same mechanism, worse: **3/12**, and missed by my own heuristic |

## Verified on live IRIS 2026.1 Build 235U

- `#1012` reproduced verbatim before fixing
- `DriftReport` exercised in all three states: `in sync`, `ONLY ON DISK: …`, `ONLY IN IRIS: …`
- snippet **re-extracted from `SKILL.md`** and compiled again — what ships is what was tested
- replace-vs-merge settled from `%Import`'s own dictionary entry, not from the issue text

## Not verified, and not verifiable from this repo

**Whether the trigger scoping works.** The only test is `ALERT-NEG-01` / `SEC-NEG-01` / `DTL-NEG-01` re-run on codex *plus the corresponding positives* — and the campaign session cannot pin an unmerged PR. That is the reason this is being cut now.

Prior art says it should hold: scoping DICOM's triggers in #57 took its misfire **0/3 → 3/3 → 6/6** while `DICOM-FIRE-01` held **5/5 → 4/5 → 6/6**, same CLI, both directions. But DICOM's replacements were distinctive nouns (C-STORE, PACS, AE Title) and these are phrases still containing the generic word. Prior art, not proof.

## Known and not fixed here

- **#122** — the Stop gate blocks every turn for a two-day-old put, while its message promises once per session. Found by it firing on this release's own work.
- **#115** — orphan-run tracking.

## Gates

34/34 examples compile with cleanup verified · tier 1 7/7 · hooks unchanged from 1.8.4, not re-gated.

Manifest: **20 skills / 9 hooks / 4 agents / 37 example artefacts (34 .cls)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)