### PR TITLE
fix(hooks): the adapter rule had a bypass the plugin teaches, and the stop gate could not stop (#122, #124, #125)

### DIFF
--- a/.github/workflows/test-hooks.yml
+++ b/.github/workflows/test-hooks.yml
@@ -1,0 +1,35 @@
+# test-hooks: regression tests for the two BLOCKING hooks.
+#
+# Both defects fixed in #122 and #124 shipped for many releases. One was found by reading a
+# regex, the other by a corpus sweep. Neither was caught by a test, because the hooks had
+# none — and a hook that stops firing fails OPEN: no deny, no warning, no log line, and the
+# next run looks clean because nothing was ever checked.
+#
+# These run in ~2s with no IRIS and no network. See scripts/test_hooks.py for what each
+# case was before its fix.
+
+name: test-hooks
+
+on:
+  push:
+    paths:
+      - 'hooks/**'
+      - 'scripts/test_hooks.py'
+      - '.github/workflows/test-hooks.yml'
+  pull_request:
+    paths:
+      - 'hooks/**'
+      - 'scripts/test_hooks.py'
+      - '.github/workflows/test-hooks.yml'
+  workflow_dispatch:
+
+jobs:
+  hooks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: hook regression tests
+        run: python3 scripts/test_hooks.py

--- a/hooks/conformance_prescan.py
+++ b/hooks/conformance_prescan.py
@@ -32,10 +32,10 @@ def read_source(ti):
 # and NONE of "none_of" match. Conservative to avoid false positives; the agent confirms.
 CHECKS = [
     ("CR-1", "pass-through BP instead of a MessageRouter rule",
-     [r"Extends\s+Ens\.BusinessProcess\b", r"\.Transform\(", r"SendRequestAsync\("],
+     [r"Extends\s*[\s(][^{]*Ens\.BusinessProcess\b", r"\.Transform\(", r"SendRequestAsync\("],
      [r"Ens\.BusinessProcessBPL"]),
     ("CR-2", "hand-rolled file parser instead of a RecordMap",
-     [r"Extends\s+Ens\.BusinessService\b", r"EnsLib\.File\.InboundAdapter", r"(\$Piece\(|\.ReadLine\()"],
+     [r"Extends\s*[\s(][^{]*Ens\.BusinessService\b", r"EnsLib\.File\.InboundAdapter", r"(\$Piece\(|\.ReadLine\()"],
      []),
     ("CR-4", "DTL written as <code> with no <assign>",
      [r"Ens\.DataTransformDTL", r"<code>"],

--- a/hooks/conformance_stop_gate.py
+++ b/hooks/conformance_stop_gate.py
@@ -33,15 +33,21 @@ TWO CHECKS, DELIBERATELY DIFFERENT IN KIND
    never invoked the reviewer, say so once. This one is a nudge with teeth rather than a
    proof of error, so it blocks a single time and then gets out of the way.
 
-Both respect `stop_hook_active`, so the model is interrupted at most once per session and
-can always proceed after answering. A gate that cannot be satisfied is a gate that gets
-disabled.
+Both respect `stop_hook_active`, and both are additionally bounded by a session cutoff and a
+persisted latch (#122). That combination — not `stop_hook_active` alone — is what makes the
+model interrupted at most once per body of work. `stop_hook_active` is true only while the
+model is already being re-invoked by THIS hook; it resets on every new user turn, so on its
+own it prevents an infinite loop within one turn and nothing more. Relying on it for "once
+per session" is how this gate came to fire on seventeen consecutive turns, over classes
+written the previous day, in turns that authored nothing.
+
+A gate that cannot be satisfied is a gate that gets disabled.
 
 NOT MEASURED. That 0/206 is measured; whether this moves it is not, and cannot be from the
 skills session — it needs an eval pass (issue #102). Check (1) does not depend on model
 behaviour and so cannot regress to zero; check (2) might.
 """
-import sys, json, os, re
+import sys, json, os, re, hashlib, calendar, time
 
 # Every exit path in this hook is silent by design — an allowing hook writes no
 # attachment and produces no transcript event. That makes a hook that never fires
@@ -152,7 +158,126 @@ def transcript_set(path):
     return files
 
 
-def scan_transcript(path):
+
+# --- #122: recency bound + a real once-per-session latch --------------------------------
+#
+# Two defects, independent, and fixing either alone leaves the other. Both were measured
+# against a live transcript in which this gate fired on SEVENTEEN consecutive user turns.
+#
+# 1. NO RECENCY BOUND. scan_transcript accumulated `put` over the entire transcript with no
+#    horizon, so classes written on 2026-08-28 gated every turn on 2026-08-29 — through two
+#    releases, in turns that authored nothing. A transcript is not a working session: it
+#    survives /exit and resume, and spans days.
+#
+#    The proxy for a session boundary is a long gap between records. That adapts, where a
+#    fixed max-age does not: a genuine multi-hour build keeps all of its puts, while work
+#    resumed the next morning correctly starts clean.
+#
+# 2. `stop_hook_active` CANNOT EXPRESS "ONCE PER SESSION". It is true only while the model is
+#    already being re-invoked by this hook, and it resets on every new user turn. It prevents
+#    an infinite loop within one turn and nothing more. The docstring's "interrupted at most
+#    once per session" and the message's "this fires once per session, not in a loop" were
+#    both promising something the mechanism could not deliver — and the documented escape
+#    hatch ("say so and stop again") had nowhere to record that it had been said.
+#
+#    So the latch is written to disk, keyed on the transcript, holding a signature of the
+#    body of work it fired about. Same unreviewed work -> already said, stay silent. New
+#    classes -> new signature -> it speaks again, which is correct.
+#
+# The signature deliberately ignores WHICH branch fired. Clearing the orphan condition used
+# to hand the turn straight to the no-review branch, which read to the user as a gate that
+# would not stop. One body of work gets one interruption.
+
+SESSION_GAP_HOURS = float(os.environ.get("IRIS_INTEROP_STOP_GATE_GAP_HOURS", "4") or 4)
+
+
+def _epoch(rec):
+    """Epoch seconds from a transcript record's ISO-8601 timestamp, or None."""
+    ts = rec.get("timestamp")
+    if not isinstance(ts, str) or not ts:
+        return None
+    t = ts.strip().replace("Z", "+0000").replace("z", "+0000")
+    t = re.sub(r"\.(\d{1,6})\d*", r".\1", t)          # trim over-long fractional seconds
+    t = re.sub(r"([+-]\d{2}):(\d{2})$", r"\1\2", t)     # +00:00 -> +0000
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f%z", "%Y-%m-%dT%H:%M:%S%z",
+                "%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            d = time.strptime(t, fmt)
+        except ValueError:
+            continue
+        try:
+            return calendar.timegm(d) - (d.tm_gmtoff or 0) if getattr(d, "tm_gmtoff", None) else calendar.timegm(d)
+        except Exception:
+            return calendar.timegm(d)
+    return None
+
+
+def session_cutoff(path):
+    """Epoch second at which the CURRENT working session starts.
+
+    The last inter-record gap longer than SESSION_GAP_HOURS is treated as a session
+    boundary; anything before it belongs to a previous sitting. Returns 0.0 when there is
+    no such gap (one continuous session) or when timestamps cannot be read, so an
+    unparseable transcript degrades to the old behaviour rather than to silence.
+    """
+    stamps = []
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                try:
+                    e = _epoch(json.loads(line))
+                except Exception:
+                    continue
+                if e:
+                    stamps.append(e)
+    except OSError:
+        return 0.0
+    stamps.sort()
+    gap, cutoff = SESSION_GAP_HOURS * 3600.0, 0.0
+    for a, b in zip(stamps, stamps[1:]):
+        if b - a > gap:
+            cutoff = b
+    return cutoff
+
+
+def _latch_path(transcript):
+    d = os.path.join(os.path.expanduser("~"), ".claude", "iris-interop-skills", "stop-gate")
+    try:
+        os.makedirs(d, exist_ok=True)
+    except OSError:
+        return None
+    key = hashlib.sha1(os.path.abspath(transcript).encode("utf-8")).hexdigest()[:16]
+    return os.path.join(d, key + ".json")
+
+
+def latch_seen(transcript, signature):
+    """True if this exact body of unreviewed work has already been raised once."""
+    p = _latch_path(transcript)
+    if not p:
+        return False
+    try:
+        with open(p, encoding="utf-8") as fh:
+            return json.load(fh).get("signature") == signature
+    except Exception:
+        return False
+
+
+def latch_record(transcript, signature):
+    p = _latch_path(transcript)
+    if not p:
+        return
+    try:
+        with open(p, "w", encoding="utf-8") as fh:
+            json.dump({"signature": signature, "at": int(time.time())}, fh)
+    except OSError:
+        pass  # a latch we cannot write costs a repeat, never a crash
+
+
+def put_signature(put):
+    return hashlib.sha1("\n".join(sorted(put)).encode("utf-8")).hexdigest()
+
+
+def scan_transcript(path, cutoff=0.0):
     """Return (classes put into IRIS this session, whether a conformance pass ran).
 
     Matches the JSON keys of genuine tool invocations, never prose: the router's own text
@@ -176,6 +301,10 @@ def scan_transcript(path):
                     rec = json.loads(line)
                 except Exception:
                     continue
+                if cutoff:
+                    e = _epoch(rec)
+                    if e and e < cutoff:
+                        continue  # #122: a previous working session, not this one
                 msg = rec.get("message") or {}
                 content = msg.get("content")
                 if not isinstance(content, list):
@@ -256,12 +385,21 @@ def main():
         _trace("no_transcript_path", keys=sorted(data.keys()))
         return
 
-    put, reviewed = scan_transcript(transcript)
+    cutoff = session_cutoff(transcript)
+    put, reviewed = scan_transcript(transcript, cutoff)
     if not put:
         _trace("no_puts", transcript=transcript,
                exists=os.path.exists(transcript),
-               lines=_count_lines(transcript), reviewed=reviewed)
+               lines=_count_lines(transcript), reviewed=reviewed, cutoff=cutoff)
         return  # this session authored no interop classes; nothing to gate
+
+    # #122: one body of unreviewed work earns one interruption, across BOTH branches.
+    # Clearing the orphan condition used to hand the turn straight to the no-review
+    # branch, which reads to the user as a gate that will not stop.
+    signature = put_signature(put)
+    if latch_seen(transcript, signature):
+        _trace("latched", puts=len(put), signature=signature[:12])
+        return
 
     root = project_root(data)
     orphans = find_orphans(root, put)
@@ -273,6 +411,7 @@ def main():
             for c in orphans[:15]
         )
         more = "\n  ... and {} more".format(len(orphans) - 15) if len(orphans) > 15 else ""
+        latch_record(transcript, signature)
         block(
             "CR-12 — {} of the {} class(es) this session wrote into IRIS exist ONLY in the "
             "namespace:\n\n{}{}\n\n"
@@ -286,6 +425,7 @@ def main():
 
     if not reviewed:
         _trace("blocking_no_review", put=len(put))
+        latch_record(transcript, signature)
         block(
             "The conformance pass has not run. This session authored {} interop class(es) and "
             "every one is on disk, but nothing has checked them against the twelve criteria.\n\n"

--- a/hooks/interop_conformance_gate.py
+++ b/hooks/interop_conformance_gate.py
@@ -78,6 +78,15 @@ DICT_GLOBAL = re.compile(r"(?i)\^odd(DEF|COM)")
 #     iris_credential_list   14/14 failed      iris_production_item   7/7 failed
 #     iris_production        15/17 failed      iris_lookup_manage      1/1 failed
 #
+# THAT 95% IS VERSION-BOUND, and the file must say so. It was measured against MCP <= 0.8.4,
+# where all six of these tools declared an EMPTY input schema — `namespace` was on the wire but
+# undeclared, so a model could not discover it from the handshake. MCP 0.11.0 declares it on all
+# six. The wire key did not move and this rule still works, but the deny-rate WILL fall on
+# 0.11.0+ for that reason alone. Do not read the drop as agents getting better; to separate the
+# effects, measure deny-rate on 0.8.4 vs 0.11.0 with everything else held. The rule stays either
+# way: passing `namespace` explicitly is never wrong, and declared-but-optional is not the same
+# as reliably passed. See #125.
+#
 # Deliberately NOT listed, because the same capture proves they are fine without it:
 # `check_config` (0/41 failures) and `iris_get_log` (0/40). A blanket rule would be wrong.
 # Also not listed: iris_doc / iris_compile / iris_query / iris_execute / iris_test /
@@ -206,18 +215,29 @@ def main():
                 )
 
     if content:
-        m = re.search(r"Extends\s+([A-Za-z0-9_.%]*(?:Inbound|Outbound)Adapter)\b", content)
-        if m:
-            looks_bs_bo = any(s in BS_BO_SEGS for nm in names for s in nm.split("."))
-            if looks_bs_bo:
-                adapter = m.group(1)
-                deny(
-                    "A Business Service/Operation must Extend Ens.BusinessService / Ens.BusinessOperation "
-                    "and declare its adapter as `Parameter ADAPTER = \"%s\";` — not Extend the adapter "
-                    "(%s) directly (that yields an empty, non-functional component). Fix the superclass + "
-                    "ADAPTER parameter and retry. See Skill(iris-interop-skills:business-services) / "
-                    ":business-operations." % (adapter, adapter)
-                )
+        # Anchored to a real class-definition line: skips /// comments and prose, and accepts both
+        # `Extends Super` and the parenthesized list `Extends (A, B)` the plugin's own examples use.
+        cm = re.search(r"(?im)^\s*Class\s+([A-Za-z0-9_.%]+)\s+Extends\s+(\(?[^{\n]+)", content)
+        if cm:
+            cls_name = cm.group(1)
+            supers = [s.strip().strip("()") for s in cm.group(2).split(",")]
+            adapter = next((s for s in supers if re.search(r"(?:Inbound|Outbound)Adapter$", s)), None)
+            if adapter:
+                # Pair against the class declared IN THIS CONTENT, not the union of `names`.
+                base = cls_name[:-4] if cls_name.lower().endswith(".cls") else cls_name
+                segs = base.split(".")
+                type_segs = segs[1:-1] if len(segs) > 2 else []
+                # Honour the docstring: a genuine custom adapter is left alone.
+                is_adapter = cls_name.endswith("Adapter") or "Adapter" in type_segs
+                if not is_adapter and any(s in BS_BO_SEGS for s in type_segs):
+                    deny(
+                        "A Business Service/Operation must Extend Ens.BusinessService / Ens.BusinessOperation "
+                        "and declare its adapter as `Parameter ADAPTER = \"%s\";` — not Extend the adapter "
+                        "(%s) directly (that yields an empty, non-functional component). Fix the superclass + "
+                        "ADAPTER parameter and retry. See Skill(iris-interop-skills:business-services) / "
+                        ":business-operations." % (adapter, adapter)
+                    )
+
     # no output -> allow
 
 

--- a/hooks/silent_execute_guard.py
+++ b/hooks/silent_execute_guard.py
@@ -31,6 +31,12 @@ def main():
         data = json.load(sys.stdin)
     except Exception:
         return
+    # NOTE (#125): this reads the tool RESPONSE, so it never sees a call the client rejected
+    # locally on schema grounds. MCP 0.11.0 added `required` entries to tools that previously
+    # declared no schema, so incomplete calls that used to travel and fail at the server can now
+    # be refused client-side, producing no tool_response and no PostToolUse event at all. This
+    # hook does not break; its denominator quietly loses those calls. Do not compare rates
+    # across that pin boundary without accounting for it.
     resp = data.get("tool_response", data.get("tool_output", {}))
     p = payload(resp)
     out = p.get("output", None)

--- a/hooks/tdd_first_green.py
+++ b/hooks/tdd_first_green.py
@@ -60,6 +60,12 @@ def main():
     if not isinstance(target, str) or not target.strip():
         return
 
+    # NOTE (#125): this reads the tool RESPONSE, so it never sees a call the client rejected
+    # locally on schema grounds. MCP 0.11.0 added `required` entries to tools that previously
+    # declared no schema, so incomplete calls that used to travel and fail at the server can now
+    # be refused client-side, producing no tool_response and no PostToolUse event at all. This
+    # hook does not break; its denominator quietly loses those calls. Do not compare rates
+    # across that pin boundary without accounting for it.
     raw = data.get("tool_response", data.get("tool_result", ""))
     if isinstance(raw, str):
         try:

--- a/scripts/test_hooks.py
+++ b/scripts/test_hooks.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Regression tests for the two blocking hooks.
+
+Both defects fixed in #122 and #124 shipped for many releases and were found by reading
+code and by a corpus sweep — neither was caught by a test, because there were none. Every
+case below is one that was WRONG before its fix, plus the controls proving the fix did not
+simply make the hook quieter.
+
+A silent gate and a working gate are indistinguishable from the outside, so the positive
+controls matter more than the negative ones. Run from the repo root:
+
+    python3 scripts/test_hooks.py
+"""
+import json, os, subprocess, sys, tempfile, time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GATE = os.path.join(ROOT, "hooks", "interop_conformance_gate.py")
+STOP = os.path.join(ROOT, "hooks", "conformance_stop_gate.py")
+sys.path.insert(0, os.path.join(ROOT, "hooks"))
+import conformance_stop_gate as g  # noqa: E402
+
+NOW = time.time()
+failures = []
+
+
+def run_hook(script, payload):
+    """DENY/ALLOW, with a crash reported as a crash.
+
+    Merging stderr into stdout here would score a Python traceback as a deny, which makes
+    a broken hook look like a working one. Keep the streams apart.
+    """
+    p = subprocess.run([sys.executable, script], input=json.dumps(payload),
+                       capture_output=True, text=True)
+    if p.returncode != 0 or p.stderr.strip():
+        return "CRASH: " + (p.stderr.strip().splitlines()[-1][:120] if p.stderr.strip() else "rc")
+    return "DENY" if p.stdout.strip() else "ALLOW"
+
+
+def check(name, want, got):
+    ok = want == got
+    if not ok:
+        failures.append(name)
+    print("  {:<38}{:<16}{:<16}{}".format(name, want, got, "ok" if ok else "** MISMATCH"))
+
+
+# --------------------------------------------------------------------------- #124
+def doc(name, content, **extra):
+    return {"tool_name": "mcp__iris__iris_doc",
+            "tool_input": dict({"name": name, "content": content}, **extra)}
+
+
+print("\n#124  interop_conformance_gate — adapter rule")
+print("  {:<38}{:<16}{:<16}{}".format("case", "want", "got", ""))
+
+CASES = [
+    ("non-conformant BS", "DENY",
+     doc("Demo.BS.FileIn.cls", "Class Demo.BS.FileIn Extends EnsLib.File.InboundAdapter\n{\n}")),
+    ("the fixing rewrite", "ALLOW",
+     doc("Demo.BS.FileIn.cls", 'Class Demo.BS.FileIn Extends Ens.BusinessService\n{\n'
+                               'Parameter ADAPTER = "EnsLib.File.InboundAdapter";\n}')),
+    ("author's own adapter", "ALLOW",
+     doc("Demo.Adapter.MyIn.cls", "Class Demo.Adapter.MyIn Extends EnsLib.File.InboundAdapter\n{\n}")),
+    # was DENY: looks_bs_bo scanned every segment, so a .BO. PACKAGE tripped it
+    ("real adapter under a .BO. package", "ALLOW",
+     doc("HS.Local.BO.Adapter.MyOutboundAdapter.cls",
+         "Class HS.Local.BO.Adapter.MyOutboundAdapter Extends EnsLib.HTTP.OutboundAdapter\n{\n}")),
+    # was DENY: the regex was unanchored and matched inside a /// comment
+    ("conformant class, comment names it", "ALLOW",
+     doc("Demo.BO.Http.cls",
+         "/// Business Operation. Extends Ens.BusinessOperation; do NOT Extends "
+         "EnsLib.HTTP.OutboundAdapter.\nClass Demo.BO.Http Extends Ens.BusinessOperation\n{\n"
+         'Parameter ADAPTER = "EnsLib.HTTP.OutboundAdapter";\n}')),
+    # was DENY: content was matched against the union of every name in the call
+    ("multi-doc put, names unioned", "ALLOW",
+     {"tool_name": "iris_doc",
+      "tool_input": {"names": ["Demo.Adapter.MyIn.cls", "Demo.BS.Other.cls"],
+                     "content": "Class Demo.Adapter.MyIn Extends EnsLib.File.InboundAdapter\n{\n}"}}),
+    # was ALLOW: the bypass. `[A-Za-z0-9_.%]*` cannot cross the `(`
+    ("parenthesized single superclass", "DENY",
+     doc("Demo.BS.FileIn.cls", "Class Demo.BS.FileIn Extends (EnsLib.File.InboundAdapter)\n{\n}")),
+    # was ALLOW: and this is the form skills/dicom/SKILL.md:172 teaches for a BS class
+    ("parenthesized multi superclass", "DENY",
+     doc("Demo.BS.FileIn.cls",
+         "Class Demo.BS.FileIn Extends (Ens.BusinessService, EnsLib.File.InboundAdapter)\n{\n}")),
+    ("the plugin's own DICOM example", "ALLOW",
+     doc("DICOM.BS.RESTService.cls",
+         "Class DICOM.BS.RESTService Extends (Ens.BusinessService, %CSP.REST)\n{\n}")),
+    ("BO named .Operation. (rule 1)", "DENY",
+     doc("Demo.Operation.Send.cls", "Class Demo.Operation.Send Extends Ens.BusinessOperation\n{\n}")),
+    ("lowercase class/extends", "DENY",
+     doc("Demo.BS.FileIn.cls", "class Demo.BS.FileIn extends EnsLib.File.InboundAdapter\n{\n}")),
+]
+for name, want, payload in CASES:
+    check(name, want, run_hook(GATE, payload))
+
+
+# --------------------------------------------------------------------------- #122
+def iso(off):
+    return time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(NOW + off))
+
+
+def rec(off, tool, inp):
+    return json.dumps({"timestamp": iso(off),
+                       "message": {"content": [{"type": "tool_use", "name": tool, "input": inp}]}})
+
+
+def transcript(lines):
+    fd, p = tempfile.mkstemp(suffix=".jsonl")
+    with os.fdopen(fd, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+    return p
+
+
+def stop(tpath, cwd, **extra):
+    p = subprocess.run([sys.executable, STOP],
+                       input=json.dumps(dict({"transcript_path": tpath, "cwd": cwd}, **extra)),
+                       capture_output=True, text=True)
+    if p.returncode != 0 or p.stderr.strip():
+        return "CRASH: " + (p.stderr.strip().splitlines()[-1][:120] if p.stderr.strip() else "rc")
+    if not p.stdout.strip():
+        return "ALLOW"
+    return "BLOCK/orphan" if "CR-12" in p.stdout else "BLOCK/no-review"
+
+
+def clear(t):
+    lp = g._latch_path(t)
+    if lp and os.path.exists(lp):
+        os.remove(lp)
+
+
+print("\n#122  conformance_stop_gate — recency bound and once-per-session latch")
+print("  {:<38}{:<16}{:<16}{}".format("case", "want", "got", ""))
+
+work = tempfile.mkdtemp()
+os.makedirs(os.path.join(work, "src", "Demo", "BS"), exist_ok=True)
+with open(os.path.join(work, "src", "Demo", "BS", "Live.cls"), "w") as fh:
+    fh.write("Class Demo.BS.Live {}")
+
+PUT_LIVE = {"mode": "put", "name": "Demo.BS.Live.cls", "content": "Class Demo.BS.Live {}"}
+PUT_GHOST = {"mode": "put", "name": "Demo.BO.Ghost.cls", "content": "Class Demo.BO.Ghost {}"}
+
+t = transcript([rec(-300, "iris_doc", PUT_LIVE)])
+clear(t)
+check("live put, on disk, unreviewed", "BLOCK/no-review", stop(t, work))
+check("same work, next turn (latched)", "ALLOW", stop(t, work))
+
+t = transcript([rec(-300, "iris_doc", PUT_GHOST)])
+clear(t)
+check("live put, not on disk (CR-12)", "BLOCK/orphan", stop(t, work))
+
+t = transcript([rec(-300, "iris_doc", PUT_LIVE),
+                rec(-200, "Agent", {"subagent_type": "iris-interop-skills:conformance-reviewer"})])
+clear(t)
+check("live put, reviewed", "ALLOW", stop(t, work))
+
+# the seventeen-firing bug: yesterday's classes gating today's turns
+t = transcript([rec(-26 * 3600, "iris_doc", PUT_GHOST), rec(-300, "Bash", {"command": "echo"})])
+clear(t)
+check("put 26h ago, long gap since", "ALLOW", stop(t, work))
+
+# ...but a long CONTINUOUS session is not a previous session and must still gate
+lines = [rec(-6 * 3600, "iris_doc", PUT_GHOST)]
+lines += [rec(-6 * 3600 + i * 1800, "Bash", {"command": "echo"}) for i in range(1, 12)]
+t = transcript(lines)
+clear(t)
+check("6h continuous session, no gap", "BLOCK/orphan", stop(t, work))
+
+# a latch must not swallow work that arrived after it fired
+t = transcript([rec(-300, "iris_doc", PUT_GHOST)])
+clear(t)
+stop(t, work)
+with open(t, "a") as fh:
+    fh.write(rec(-100, "iris_doc", {"mode": "put", "name": "Demo.BO.Second.cls",
+                                    "content": "Class Demo.BO.Second {}"}) + "\n")
+check("new class after a firing", "BLOCK/orphan", stop(t, work))
+
+t = transcript([rec(-300, "iris_doc", PUT_GHOST)])
+clear(t)
+check("stop_hook_active short-circuits", "ALLOW", stop(t, work, stop_hook_active=True))
+
+check("unreadable transcript", "ALLOW", stop(transcript(["{not json"]), work))
+
+print("\n{} failure(s)".format(len(failures)))
+for f in failures:
+    print("  FAILED:", f)
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
Three hook defects, each found by measurement rather than review, none of them previously covered by a test — the hooks had none.

## #124 — the adapter rule had a bypass the plugin teaches

Four wrong answers, one root cause: `looks_bs_bo` scanned every segment of every name, and the regex was unanchored, comment-blind, and unable to cross a `(`.

| case | before | after |
|---|---|---|
| real adapter under a `.BO.` **package** | DENY | ALLOW |
| conformant class whose `///` comment names the anti-pattern | DENY | ALLOW |
| multi-doc put, content matched against every name | DENY | ALLOW |
| **`Extends (EnsLib.File.InboundAdapter)`** | **ALLOW** | DENY |
| `Extends (Ens.BusinessService, EnsLib.File.InboundAdapter)` | **ALLOW** | DENY |

The false negative is the serious one: the exact anti-pattern the rule exists to block, in legal ObjectScript, defeated by one parenthesis — and it is the form **the plugin itself teaches** at `skills/dicom/SKILL.md:172`, in a BS class. The regex was byte-identical (sha1 `0e078901`) from v1.5.9 through v1.8.6, so it was open for every measured release.

Corpus exposure is **unmeasured, not zero**: only 2 adapter anti-pattern attempts occur in 4,955 class-writing puts, and P(observing 0 | gate wide open) = 0.756. The finding rests on the code path, not the corpus.

Same blind spot fixed in `conformance_prescan.py:35,38`, where line 60 already handled the parenthesized form — an inconsistency, not an unknown.

## #122 — the stop gate could not stop

Observed firing on **seventeen consecutive user turns**, over classes written the previous day, in turns that authored nothing. Two independent defects; fixing either alone leaves the other.

- **No recency bound.** `scan_transcript` accumulated puts over the whole transcript, which survives `/exit` and spans days. Now bounded by a session cutoff taken from the last inter-record gap > 4h — that adapts where a fixed max-age does not, so a 6h *continuous* session keeps all of its puts.
- **`stop_hook_active` cannot express "once per session".** It is true only while the model is already being re-invoked by this hook, and resets every user turn; it prevents an infinite loop within one turn and nothing more. The documented remedy — *"say so and stop again"* — had nowhere to record that it had been said. Replaced with a latch persisted per transcript, keyed on the body of work, so clearing the orphan branch no longer hands the turn to the no-review branch.

## #125 — documentation only

The `NS_REQUIRED` rule's 37-of-39 (95%) justification was measured against MCP ≤ 0.8.4, where those six tools declared an **empty schema** and `namespace` was undiscoverable from the handshake. 0.11.0 declares it. The rule is unaffected and stays — but the deny-rate will fall for schema reasons, and the file now says so, so nobody reads the drop as agents improving. The same note goes on the two PostToolUse hooks that key off `tool_response`, whose denominators quietly lose calls a schema-validating client now rejects locally.

## Tests

`scripts/test_hooks.py` + a CI workflow, 20 cases, ~2s, no IRIS.

Reverting `hooks/` makes the six #124 cases fail — that is the point, since a test that passes on broken code is worthless. (The #122 cases crash rather than fail cleanly against pre-fix code, because the helpers do not exist there; expected for new functionality, stated rather than dressed up.)

A hook that stops firing **fails open** — no deny, no warning, no log line, and the next run looks clean because nothing was checked. So the positive controls carry more weight than the negative ones: still blocks live unreviewed work, still blocks CR-12 orphans, still fires for new work arriving after a latch.

## Verification

- tier 1 example validation: **7/7**
- hook regression tests: **20/20**
- all 9 hooks parse; manifest unchanged at 20 skills / 9 hooks / 4 agents

Closes #124
Closes #122
Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
