### PR TITLE
fix(skills/alerting): restore the two bare Spanish triggers the 1.8.6 rewrite removed as collateral (#126)

### DIFF
--- a/skills/alerting/SKILL.md
+++ b/skills/alerting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alerting
-description: Ens.Alert router, alert dedup, production monitor, per-BO alert settings in IRIS Interoperability. Routed from interop. Triggers: Ens.Alert, Ens.AlertRequest, Send Alert on Error, alert on error, IRIS alert routing, alert dedup FunctionSet, AlertOperation, ProductionMonitorService, alerta de producción, ruta de alertas.
+description: Ens.Alert router, alert dedup, production monitor, per-BO alert settings in IRIS Interoperability. Routed from interop. Triggers: Ens.Alert, Ens.AlertRequest, Send Alert on Error, alert on error, IRIS alert routing, alert dedup FunctionSet, AlertOperation, ProductionMonitorService, alerta, notificación, alerta de producción, ruta de alertas.
 ---
 
 # Alert circuit for IRIS Interop productions


### PR DESCRIPTION
Restores the two bare Spanish triggers that the 1.8.6 rewrite removed as collateral damage. **Diff is `+alerta, +notificación` and nothing else.**

## What happened

1.8.6 narrowed alerting's triggers to stop the skill firing on Prometheus prompts, and it worked — `ALERT-NEG-01` went 4/27 (15%) → 19/20 (95%). But it also replaced both bare Spanish nouns with phrases:

```
1.8.2   alerta                notificación
1.8.6   alerta de producción  ruta de alertas
```

and `ALERT-FIRE-03-ES`, the Spanish positive, dropped 27/27 → 16/20.

## Why the deletion bought nothing

Reading the scenario prompts settles it. **`NEG-01` is an English prompt** — Kubernetes, Prometheus, Grafana, Alertmanager, PromQL — so `alerta` and `notificación` could never have matched it. What bought the +80 is the narrowing of the bare **English** generics (`alert` → `alert on error`, `dedup` → `alert dedup FunctionSet`, dropping `paging`), each of which has a Prometheus homonym in that prompt.

The Spanish deletion was collateral damage from an English-motivated fix.

## Measured before shipping

Matched codex/gpt-5.6-luna arms at MCP 0.8.4, grading generation 8:

```
ALERT-NEG-01      candidate 112/126 (89%)  vs control 100/111 (90%)   -1.2 pt   p=0.834
ALERT-FIRE-03-ES  candidate  33/35  (94%)  vs 1.8.6    16/20  (80%)  +14   pt   p=0.176
```

**The negative is safe on solid evidence; the positive gain remains unproven.** This ships on *"restores a surface removed by accident, at no measurable cost"* — not on the +14.

An earlier n=20 reading of the negative at 95% was the fluke; at n=126 the candidate sits 1.2 points from control.

## A side result worth recording

The four-cell arm that produced these numbers also **refuted the cross-lingual hypothesis** these triggers rest on: 8 Spanish *alerting* terms (84%) and 8 Spanish *billing* terms (86%) are indistinguishable on an English prompt, p=0.838. The router is not matching Spanish meaning — so the +80/+41/+49 wins in 1.8.6 do not need re-reading on that mechanism.

Verification: tier 1 example validation 7/7; diff confirmed to add exactly two tokens and remove none.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
