### PR TITLE
test(skills): enumerate the trigger-label space instead of filtering on one form (#131)

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,34 @@
+# validate-skills: structural gate over skill frontmatter.
+#
+# Exists because of #131. Two sessions independently split trigger lists on the literal
+# `Triggers:`, silently dropped the four skills that use `Triggers EN:` / `Triggers ES:`, and
+# both reported those four as carrying zero triggers. Neither query errored; a filter can only
+# confirm the rows it already matches. S4 therefore ENUMERATES the label space on every run.
+#
+# ~1s, no IRIS, no network.
+
+name: validate-skills
+
+on:
+  push:
+    paths:
+      - 'skills/**'
+      - 'scripts/validate_skills.py'
+      - '.github/workflows/validate-skills.yml'
+  pull_request:
+    paths:
+      - 'skills/**'
+      - 'scripts/validate_skills.py'
+      - '.github/workflows/validate-skills.yml'
+  workflow_dispatch:
+
+jobs:
+  skills:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: skill frontmatter checks
+        run: python3 scripts/validate_skills.py

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Structural gate over skill frontmatter.
+
+Written for #131. Two sessions independently split trigger lists on the literal `Triggers:`,
+missed the four skills that label theirs `Triggers EN:` / `Triggers ES:`, and both concluded
+those four carried ZERO trigger words. That wrong number became the premise for a filed issue,
+a committed report section, and a proposal to "fix" `report-issue` — which measurement later
+showed to be the best-behaved skill in the plugin.
+
+Neither query errored. Filtering on one label can only confirm the rows it already matches; it
+can never reveal the rows it silently drops. **A query that cannot return zero is not a check.**
+So the enforcement here is enumeration, not matching: S4 prints the whole label space every run,
+which is the thirty seconds that would have prevented all of it.
+
+    python3 scripts/validate_skills.py
+"""
+import glob, os, re, sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Any label variant currently in the tree, and any near-miss someone adds later.
+TRIGGER_LABEL = re.compile(r"\bTriggers?\b[^:\n]{0,10}:", re.I)
+
+failures = []
+
+
+def check(cid, what, bad, detail=lambda x: x):
+    if bad:
+        failures.append(cid)
+        print("  FAIL  {}  {}".format(cid, what))
+        for b in bad[:10]:
+            print("          - {}".format(detail(b)))
+        if len(bad) > 10:
+            print("          ... and {} more".format(len(bad) - 10))
+    else:
+        print("  ok    {}  {}".format(cid, what))
+
+
+def frontmatter(text):
+    """The YAML block between the first two `---` fences, or None."""
+    m = re.match(r"\A---\s*\n(.*?)\n---\s*(?:\n|$)", text, re.S)
+    return m.group(1) if m else None
+
+
+def field(fm, name):
+    """A frontmatter scalar, folded across continuation lines."""
+    m = re.search(r"(?ms)^%s:\s*(.*?)(?=^\S+:|\Z)" % re.escape(name), fm)
+    return " ".join(m.group(1).split()) if m else None
+
+
+skills = sorted(glob.glob(os.path.join(ROOT, "skills", "*", "SKILL.md")))
+print("\n{} skills under skills/\n".format(len(skills)))
+
+parsed, no_fm, no_name, name_mismatch, no_desc = {}, [], [], [], []
+for path in skills:
+    slug = os.path.basename(os.path.dirname(path))
+    fm = frontmatter(open(path, encoding="utf-8").read())
+    if fm is None:
+        no_fm.append(slug)
+        continue
+    nm, desc = field(fm, "name"), field(fm, "description")
+    if not nm:
+        no_name.append(slug)
+    elif nm != slug:
+        name_mismatch.append("{}: name: {!r}".format(slug, nm))
+    if not desc:
+        no_desc.append(slug)
+    else:
+        parsed[slug] = desc
+
+check("S1", "every skill has a frontmatter block", no_fm)
+check("S2", "frontmatter `name:` matches the directory", name_mismatch)
+check("S3", "every skill has a non-empty `description:`", no_desc + no_name)
+
+# --- S4: the #131 check. Enumerate, never filter.
+labels, inbody = {}, {}
+no_trigger, empty_trigger = [], []
+for slug, desc in parsed.items():
+    found = list(TRIGGER_LABEL.finditer(desc))
+    if not found:
+        no_trigger.append(slug)
+        continue
+    # Only the FIRST match introduces the list. Later ones are prose — `dicom` carries a
+    # "NOT a trigger: ..." note, and counting that as a label form reported a fifth variant
+    # that does not exist. Enumerating the wrong thing is still enumerating the wrong thing.
+    labels.setdefault(found[0].group(0), []).append(slug)
+    for m in found[1:]:
+        inbody.setdefault(m.group(0), []).append(slug)
+    body = desc[found[0].end():]
+    if not body.strip(" .,"):
+        empty_trigger.append(slug)
+
+check("S4", "every description carries a non-empty trigger list", no_trigger + empty_trigger)
+
+print("\n  label space in use (S4 enumerates rather than filters — see #131):")
+for lab, who in sorted(labels.items(), key=lambda kv: -len(kv[1])):
+    print("    {:>3}x  {:<16} {}".format(
+        len(who), lab, "" if len(who) > 4 else ", ".join(sorted(who))))
+if inbody:
+    print("\n  later matches, prose not labels (e.g. a \"NOT a trigger: ...\" note):")
+    for lab, who in sorted(inbody.items()):
+        print("    {:>3}x  {:<16} {}".format(len(who), lab, ", ".join(sorted(who))))
+if len(labels) > 1:
+    print("\n  NOTE: more than one label form is in use. That is not a failure — normalising\n"
+          "  the label changes text the router matches on, and this repo has measured that\n"
+          "  description edits need a before/after (#126, #127). Any ANALYSIS of trigger\n"
+          "  content must accept every form above; use the S4 regex, never a literal.")
+
+print("\nSkills: {}\n".format(
+    "all {} checks pass".format(4) if not failures else "{} FAILED".format(", ".join(failures))))
+sys.exit(1 if failures else 0)


### PR DESCRIPTION
Adds `scripts/validate_skills.py` + CI. No skill content changes.

## Why

Three trigger-label forms exist in frontmatter:

```
16x  Triggers:        the other sixteen skills
 3x  Triggers EN:  )  conformance-review, message-search-debug, report-issue
 1x  Triggers ES:  )  tdd   (leads with ES, not EN)
```

Two sessions independently wrote a parser that split on the literal `Triggers:`, silently dropped the four bilingual skills, and **both concluded those four carried zero trigger words.** That number became the premise for a filed issue, a committed report section, and a proposal to shorten `report-issue` — which measurement later showed to be the best-behaved skill in the plugin (94% recall, 0.9× breadth).

Neither query errored. **A filter can only confirm the rows it already matches; it cannot reveal the rows it drops.** So S4 enumerates the label space every run and prints it.

## Checks

| | |
|---|---|
| **S1** | every skill has a frontmatter block |
| **S2** | frontmatter `name:` matches the directory |
| **S3** | every skill has a non-empty `description:` |
| **S4** | every description carries a non-empty trigger list **under any label form** |

## Two things the enumeration caught on its first run

Both would have survived a *corrected* filter:

- **`tdd` leads with `Triggers ES:`**, not `Triggers EN:` — so a parser fixed to look for the EN form still mis-splits it.
- **`dicom` carries a `"NOT a trigger: ..."` note** in its prose. The first draft of this script counted that as a fifth label form and reported a variant that does not exist. Enumerating the wrong thing is still enumerating the wrong thing; S4 now takes only the first match as the label and lists later ones separately as prose.

## What this deliberately does not do

**It does not standardise the labels.** The label is part of the text the router matches against, so normalising it is a triggering change — and this repo has measured twice (#126, #127) that description edits need a before/after. Cosmetic consistency is not worth an unmeasured trigger edit, the more so since the between-skill finding is that description geometry predicts nothing at all.

If one of those four descriptions is edited for another reason and gets an arm, fold the normalisation into that change; it is free once a measurement is already being spent.

## Verification

- `validate_skills.py` — 4/4 on the current tree
- **negative control**: removing a trigger list from a skill makes S4 fail, then restored byte-identical
- `test_hooks.py` 20/20, `validate_examples.py` tier 1 7/7 — both unaffected
- manifest unchanged: 20 skills / 9 hooks / 4 agents

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)
