### PR TITLE
docs(skills): teach the SOAP ADAPTER, point a review at filing, and stop depending on optional envelope fields (#133, #134, #135)

### DIFF
--- a/agents/interop-builder.md
+++ b/agents/interop-builder.md
@@ -59,7 +59,7 @@ broken compile is the failure mode this rule exists to prevent.
   `$SYSTEM.OBJ.Load`, or `$SYSTEM.OBJ.Compile` — that is bypassing the MCP (see the rule above), and it
   does not fix the underlying source error. The error text tells you what to fix.
 - For `NO_TESTS_FOUND` specifically, run the `tdd` skill's recovery recipe (compile first, exact
-  qualified name, act on `hint`/`candidates`) — counting as one of your 3 attempts only after you have
+  qualified name, branch on `error_code`; use `hint`/`candidates` only if present) — counting as one of your 3 attempts only after you have
   actually changed the inputs, not after an identical re-run.
 
 ### Environment notes (native Windows IRIS)
@@ -100,7 +100,8 @@ broken compile is the failure mode this rule exists to prevent.
    returns ONLY what your code `write`s (Quit/Return values are not captured); wrap side-effecting calls
    as a `[SqlProc]` and read them back via `iris_query` if you need their output.
 6. **Run the test** with `iris_test`. If it reports `NO_TESTS_FOUND`, follow the `tdd` skill's recovery
-   recipe and the `hint`/`candidates` the tool returns (the class must extend
+   recipe, branching on the `error_code` the tool returns and using `hint`/`candidates` only when
+   they are present (the class must extend
    `%UnitTest.TestCase`/`TestProduction` and be compiled; pass the exact class name) — do not re-run the
    identical call.
 7. **Return only green** — a compiled component with a passing test. Summarize what you built, the

--- a/agents/introspect-dont-guess.md
+++ b/agents/introspect-dont-guess.md
@@ -25,7 +25,8 @@ class, column, or config item. You drive whatever IRIS MCP server is configured 
   `check_config`. Namespaces (`%SYS.Namespace*`, `Config.Namespaces`) → `check_config`, not SQL. Production
   items/settings/status (`Ens_Config.Item*`/`Setting*`/`Production`) → `iris_production`/`iris_production_item`.
 - **SQL not ObjectScript:** `iris_query` runs SQL SELECTs only; `set`/`write`/`do`/`##class`/`&sql`/
-  `^globals` are ObjectScript — that's `iris_execute`. If `iris_query` returns a `hint`, follow it.
+  `^globals` are ObjectScript — that's `iris_execute`. On a failure, branch on `error_code`; if a
+  `hint` is present, follow it, but do not depend on one being sent.
 
 ## Output
 Return the **verified** names (and a one-line note on how each was confirmed) so the caller can use them

--- a/skills/conformance-review/SKILL.md
+++ b/skills/conformance-review/SKILL.md
@@ -61,6 +61,12 @@ re-plan from scratch and it never rewrites silently.
 5. **Emit the report** (severity-tagged) → **a scoped remediation plan** → offer to **apply the safe
    fixes** (P0/P1 with an unambiguous canonical fix) only after the user confirms. Leave defensible
    choices as notes, not edits.
+6. **For *confirmed* P0/P1 findings, offer to file them** — load
+   `Skill(iris-interop-skills:report-issue)`, which dedups against existing issues and asks before
+   creating anything. Do this even when the review was asked for in its own words ("review this",
+   "is this idiomatic") and nobody mentioned an issue: filing is the *consequence* of a review, so
+   the prompt that started it will not name it. Never auto-file; `report-issue` always confirms
+   first. Skip it for P2/P3 and for anything you are not sure reproduces.
 
 ## Severity
 

--- a/skills/message-search-debug/SKILL.md
+++ b/skills/message-search-debug/SKILL.md
@@ -34,7 +34,7 @@ Heuristic: start at the Production Status page (red items?). Follow up in Event 
 
 When inspecting a running production through the IRIS MCP, reach for `iris_interop_query` / `iris_production` / `iris_production_item`. Do **not** hand-write SQL against `Ens_Util.Log` / `Ens.MessageHeader`, and never guess `%SYS.*` / `Config.*` / `Ens_Config.*` catalog tables — those guesses fail ~⅔ of the time. One typed call replaces the multi-query reconstruction (and the `SELECT MAX(ID)` watermark dance).
 
-> **The `<SYNTAX>errdone+2^%qaqqt` signature = you hand-rolled SQL through `iris_execute`.** `%qaqqt` is the SQL query compiler; it chokes on malformed/dynamic SQL (invalid predicates like `%STARTSWITH`/`%LIKE`, or `SELECT … FROM` a table that doesn't exist — `Ens_Config.Setting`, `Config.config`, `%SYS.*ELS*`). Two fixes: (1) a read-only SELECT → use `iris_query` (it goes through a real result-set path and returns a `hint` naming the right typed tool on "table not found"); (2) anything that runs ObjectScript or **generates classes** → wrap it in a `[SqlProc]` class method and call it via `iris_query`, never embed `&sql`/`%SQL.Statement` inside an `iris_execute` snippet.
+> **The `<SYNTAX>errdone+2^%qaqqt` signature = you hand-rolled SQL through `iris_execute`.** `%qaqqt` is the SQL query compiler; it chokes on malformed/dynamic SQL (invalid predicates like `%STARTSWITH`/`%LIKE`, or `SELECT … FROM` a table that doesn't exist — `Ens_Config.Setting`, `Config.config`, `%SYS.*ELS*`). Two fixes: (1) a read-only SELECT → use `iris_query` (it goes through a real result-set path and returns a structured failure envelope — branch on its `error_code`; a `hint` naming the right typed tool is usually included but is not guaranteed); (2) anything that runs ObjectScript or **generates classes** → wrap it in a `[SqlProc]` class method and call it via `iris_query`, never embed `&sql`/`%SQL.Statement` inside an `iris_execute` snippet.
 
 > **Always pass `namespace`.** It is documented as optional on these tools and it is not: it
 > resolves `Ens.Director` / `Ens_Config.*` in whatever namespace the connection defaults to, and if
@@ -63,7 +63,7 @@ When inspecting a running production through the IRIS MCP, reach for `iris_inter
 | SQL-Gateway connections | `introspect-dont-guess` plugin agent (an agent, not a skill; no agent tool → `interop` §"Resolving real names") / `iris_table_info` (no SQL catalog table) |
 | Namespaces | `check_config` (not a SQL table) |
 
-If you do fall back to raw `iris_query` and hit "table not found", **read the `hint`** it returns — it names the typed tool for that exact case.
+If you do fall back to raw `iris_query` and hit a table-not-found failure, **branch on the `error_code`** — it and `error` are the only fields guaranteed on a failure envelope. A `hint` naming the typed tool is *usually* there and worth reading when it is, but its wording is not stable across server releases and one of the two supported MCP servers may not send one at all. If there is no hint, go to the typed-tool table above rather than waiting for the server to name it.
 
 ### Where raw SQL IS the right answer
 

--- a/skills/soap-bo/SKILL.md
+++ b/skills/soap-bo/SKILL.md
@@ -156,6 +156,48 @@ Document every patch in the class header with a stable tag (e.g. `///PYD20260513
 
 For diagnosing wire-level issues on a SOAP BO, use a per-BO `SoapLogFile` setting rather than the namespace-wide `^ISCSOAP("Log")` toggle. Each BO writes to its own log file path, settable at runtime from the portal — covered in `message-search-debug` §"Per-BO SOAP tracing".
 
+## Canonical pattern — the SOAP BO class
+
+The wizard generates the *client* (`Pkg.WSC.*`); it does **not** generate the Business Operation.
+You write that, and it is an ordinary `Ens.BusinessOperation` whose adapter is the typed SOAP one:
+
+```objectscript
+Class MyApp.BO.WeatherService Extends Ens.BusinessOperation
+{
+Parameter ADAPTER = "EnsLib.SOAP.OutboundAdapter";
+Parameter INVOCATION = "Queue";
+
+/// Re-declare Adapter with the concrete type so `..Adapter.<method>` resolves to the
+/// adapter's own API instead of the generic Ens.OutboundAdapter.
+Property Adapter As EnsLib.SOAP.OutboundAdapter;
+
+Method GetForecast(pReq As MyApp.SOAP.WeatherService.GetForecastRequest,
+                   Output pResp As MyApp.SOAP.WeatherService.GetForecastResponse) As %Status
+{
+    Set tClient = ##class(MyApp.WSC.WeatherService).%New()
+    Set tClient.Location = ..Adapter.WebServiceURL   // adapter owns the endpoint + credentials
+    // ... invoke the generated client method, map its result onto pResp ...
+    Quit $$$OK
+}
+
+XData MessageMap
+{
+<MapItems>
+  <MapItem MessageType="MyApp.SOAP.WeatherService.GetForecastRequest">
+    <Method>GetForecast</Method>
+  </MapItem>
+</MapItems>
+}
+}
+```
+
+**`Parameter ADAPTER = "EnsLib.SOAP.OutboundAdapter";` is the line that makes this a SOAP BO.**
+Extending the adapter directly instead yields an empty, non-functional component — and a
+PreToolUse gate blocks that put (see `component-map` for the task→component map). Take the
+endpoint, credentials and timeout from the adapter's settings rather than hard-coding them in the
+generated client; that is the whole reason for using the typed adapter over a bare
+`%SOAP.WebClient`.
+
 ## Canonical pattern — calling the SOAP BO
 
 ```objectscript

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -368,9 +368,36 @@ error. Work the cause instead, in this exact order:
 2. **Run `iris_test` with the EXACT compiled class name** — fully qualified, case-correct
    (`MyApp.Tests.DT.Censo2Menus`, not `Censo2Menus`, not `myapp.tests...`). An unqualified or
    mis-cased name is the most common cause.
-3. **Act on the tool's `hint` / `candidates`.** `iris_test` returns these on a miss — they list the
-   names it *can* see. Pick the matching candidate and re-run with that exact name; do not guess a third
-   variant or fall back to running `Run()` from the terminal.
+3. **Branch on `error_code`, not on the prose.** `error_code` and `error` are the only fields
+   guaranteed on every failure envelope. `hint`, `candidates`, `did_you_mean` and `cause` are
+   **optional enrichment** — use them when present, never depend on them. Hint *wording* is not
+   stable across server releases, and one of the two supported MCP servers returns no `candidates`
+   at all, so a step that waits for them strands you.
+
+   ```
+   NO_TESTS_FOUND      the pattern matched no test class.
+                       If `candidates` is present and non-empty, pick the match and re-run with
+                       that exact name.
+                       An EMPTY `candidates` is a DIFFERENT FACT, not a missing field: it means
+                       the namespace holds no compiled test classes at all — go back to step 1,
+                       the compile is what failed.
+                       If `candidates` is absent entirely, the server does not send them. Do not
+                       wait for it; go to step 4.
+
+   NO_RUNNABLE_TESTS   the class exists and exposes nothing runnable. Here — and only here —
+                       `cause` is present and says which:
+                         NOT_A_TEST_CLASS            wrong superclass          -> step 4
+                         NO_TEST_METHODS             no Test* method           -> step 4
+                         PRODUCTION_PARAMETER_EMPTY  missing Parameter PRODUCTION -> step 1 (#5001)
+                         UNKNOWN, or anything not listed above
+                                                     -> report `cause` verbatim and stop
+                       `cause` values change between releases too; never assume the list is closed.
+
+   anything else       report `error_code` and `error` verbatim and STOP. There are ~88 codes and
+                       new ones ship; a ladder that recognises a few and silently does nothing on
+                       the rest is the bug this step exists to prevent. Do not guess a third name
+                       variant, and do not fall back to running `Run()` from the terminal.
+   ```
 4. **Verify the superclass.** The class must extend `%UnitTest.TestProduction` — never
    `%UnitTest.TestCase`, which is not an escape hatch from a `#5001` here any more than anywhere
    else (see §"Baseline class" and the fixed-points rule below) — and have at least one `Test*`


### PR DESCRIPTION
Three body edits. **No frontmatter `description:` changes** — all 24 description blocks verified **byte-identical** before and after, so no skill's fire rate can move and no pinned eval cell is invalidated.

## #135 — `soap-bo` never showed what its own oracle asserts

```
skills/soap-bo/SKILL.md   (before)
  Parameter ADAPTER lines ................ 0
  Extends Ens.BusinessOperation skeletons  0
  EnsLib.SOAP.OutboundAdapter mentions ... 1   — inside a // comment
```

Meanwhile the SessionStart bootstrap **and** `interop_conformance_gate.py` both enforce the convention. **The plugin blocked the mistake without ever showing the correct form.** `SOAPBO-BUILD-01 / TestBoIsASoapBusinessOperation` fails 5/18 asserting exactly `ADAPTER = "EnsLib.SOAP.OutboundAdapter"`.

Adds a BO skeleton mirroring the shape `business-operations/SKILL.md:40` already uses for SQL.

## #133 — the review→file path existed only in an agent that never spawns

The onward pointer lived solely in `agents/conformance-reviewer.md:55` — an agent measured spawning **0 times in 206 runs**. `conformance-review` itself, at **100% recall when expected**, never mentioned `report-issue`. So a review-shaped prompt left `report-issue` matching text that never says "issue": **0/4 on claude for that scenario, against 48/48 on its direct-request scenarios.**

Adds step 6, and says explicitly that filing is the *consequence* of a review so the prompt will not name it.

## #134 — six sites keyed recovery on optional envelope fields

Now branch on **`error_code`**, the only guaranteed field. Established with the fork's author **from its source**, not inferred:

- **~88 distinct error codes** exist — enumeration is hopeless, so the default branch is the *primary path*. `MALFORMED_RESULT` shipped four hours after the contract was stated.
- Which codes a deployment can emit depends on **`IRIS_TOOLSET`, a runtime setting** — no static list in a skill can be correct.
- **Near-duplicates exist today** (`INVALID_PARAM`/`INVALID_PARAMS`, `MISSING_PARAMETER`/`MISSING_PARAMS`), so an enumerated branch silently misses its twin.
- **The ladder is two levels.** `NOT_A_TEST_CLASS` is a `cause` value *inside* `NO_RUNNABLE_TESTS`, never an `error_code`. `cause` is optional in general but **guaranteed within its own code** — safe there, nowhere else — and needs its own default, since their #66 retired a cause value.
- An **empty `candidates`** on `NO_TESTS_FOUND` is a *different fact* (no compiled test classes at all), not a missing field.

The worst exposure was `message-search-debug` reading `hint` **text** for content; hint wording is explicitly not stable across releases.

## Verification

| | |
|---|---|
| descriptions byte-identical | **24/24** |
| `validate_skills.py` | 4/4 |
| `test_hooks.py` | 20/20 |
| tier 1 examples | 7/7 |
| manifest | unchanged, 20 skills / 9 hooks / 4 agents |
| bare `act on hint/candidates` remaining | 0 |

The new `soap-bo` skeleton **passes the conformance gate**; the same class extending the adapter directly is **denied** — checked by running both through the real hook.

Closes #133
Closes #134
Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
