### PR TITLE
release: 1.8.7 — two blocking hooks that misfired, and skills that leaned on what the server might not send

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.6"
+    "version": "1.8.7"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.6",
+      "version": "1.8.7",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Version bump only; all content merged in PRs #129, #130, #132 and #136.

**Hooks** — the adapter rule's parenthesized-superclass bypass (open, byte-identical, from v1.5.9 through v1.8.6, on syntax the plugin teaches at `skills/dicom/SKILL.md:172`); the stop gate that fired on **seventeen consecutive turns** because `stop_hook_active` cannot express *once per session*; NS_REQUIRED's justification now version-bound.

**Skills** — alerting's two bare Spanish triggers restored; `soap-bo` finally shows `Parameter ADAPTER = "EnsLib.SOAP.OutboundAdapter"`; `conformance-review` points onward to `report-issue`; six recovery sites branch on `error_code` instead of on fields the server may not send.

**Tests** — `test_hooks.py` (20 cases) and `validate_skills.py` (4 checks), both in CI. The hooks previously had none.

**No description changes since 1.8.6 except alerting's**, which is #126 and deliberate — so eval cells pinned at 1.8.6 remain valid for every skill but alerting.

Verified: validate_skills 4/4, test_hooks 20/20, tier 1 7/7, manifest unchanged at 20/9/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)