### PR TITLE
docs(hl7-schemas): segment placement in the definition decides the access path

### DIFF
--- a/skills/hl7-schemas/SKILL.md
+++ b/skills/hl7-schemas/SKILL.md
@@ -116,6 +116,45 @@ Notes:
 - `required` = `'R'` (required) or `'O'` (optional). `ifrepeating` = `'0'` or `'1'`.
 - A `<MessageType>` linking the message-type name to its structure is required for DTLs that reference `PharmacySchema:ORM_O01` to resolve.
 
+### Where you place the segment in the definition decides how you address it — HIGH severity
+
+The `definition` string is not just a validity rule; it *is* the path grammar. Put the
+Z-segment at the top level and it is `ZAL:1`. Put the same segment inside a repeating
+group and that path stops resolving — and nothing tells you, because
+`ResolveSchemaTypeToDocType` still returns the DocType and the DTL still compiles.
+
+Measured on IRIS 2026.1, same message and same category, only the placement changed:
+
+| placement in `definition` | path that reads field 1 |
+|---|---|
+| top level — `…~}~}~[~ZAL~]~[~DSC~]` | `ZAL:1` |
+| inside the repeating order group — `…~[~{~OBX~…~}~]~[~{~ZAL~}~]~…` | `PIDgrpgrp(1).ORCgrp(1).ZAL(1):1` |
+
+Two traps in the nested form:
+
+- **The group prefix is mandatory.** Plain `ZAL:1` returns `""` with
+  `<Ens>ErrGeneral: No segment found at path 'ZAL'` — the same error a *missing* category
+  produces, so it reads like the schema never imported when in fact it imported fine.
+- **So is the repetition index.** `PIDgrpgrp(1).ORCgrp(1).ZAL:1` also fails; only
+  `ZAL(1)` resolves. A segment inside `{~…~}` is always subscripted.
+
+In a DTL this surfaces as a target property that is simply empty — `<assign>` with an
+unresolvable source path is not a compile error. Confirm the path before writing the
+transform:
+
+```objectscript
+// The segment is present either way — this is only a check that it parsed,
+// NOT the way to read it (that is the character-counting shortcut in disguise).
+Write msg.GetSegmentAt(5).Name, " ", msg.GetSegmentAt(5).GetValueAt(1), !
+// The real question: does the path you are about to put in the DTL resolve?
+Set tSC = $$$OK
+Write msg.GetValueAt("ZAL:1", , .tSC), " ", $System.Status.GetErrorText(tSC), !
+```
+
+Prefer top-level placement for a trailing Z-segment unless the partner's own
+specification genuinely nests it — the path stays short, and DTL authors in the visual
+editor get `ZAL:…` rather than a four-part group path.
+
 ### SqlProc wrapper
 
 ```objectscript


### PR DESCRIPTION
Found while diagnosing #138. Three `HL7SCH-BUILD-01` runs each authored a correct custom schema
category and still scored 0. Most of that is an oracle defect on the testsuite side — it hardcodes
a category name the prompt never gives, and I've written that up on #138 and routed it there. This
PR is the half that is genuinely ours.

## The gap

Where a Z-segment sits in the `definition` string is the **path grammar**, not just a validity
rule. The skill's canonical example placed the segment at top level and never said the placement
had a consequence.

Measured on IRIS 2026.1 (Build 235U) with the same message and the same category, changing only
the placement:

| placement in `definition` | path that reads field 1 |
|---|---|
| top level — `…~}~}~[~ZAL~]~[~DSC~]` | `ZAL:1` |
| inside the repeating order group — `…~[~{~OBX~…~}~]~[~{~ZAL~}~]~…` | `PIDgrpgrp(1).ORCgrp(1).ZAL(1):1` |

Both nested traps are silent, and one is actively misleading:

- **The group prefix is mandatory.** Plain `ZAL:1` returns `""` with
  `<Ens>ErrGeneral: No segment found at path 'ZAL'` — the *same* error a missing category
  produces, so a schema that imported perfectly reads as one that never imported at all.
- **So is the repetition index.** `PIDgrpgrp(1).ORCgrp(1).ZAL:1` fails too; only `ZAL(1)` resolves.
  A segment inside `{~…~}` is always subscripted.

In a DTL neither shows up at compile time — `<assign>` with an unresolvable source path is not an
error — so the symptom is a target property that is simply empty. That is exactly the failure mode
that produced a 0 while the run scored 57–85 on everything else.

## What this adds

The comparison table, both traps stated as traps, a two-line check to run *before* writing the
transform, and a recommendation to prefer top-level placement for a trailing Z-segment unless the
partner's own specification genuinely nests it.

## Verification

Live IRIS 2026.1 via `iris-interop-dev` 0.13.0, both placements executed directly rather than
reasoned about — including replaying a failing run's schema XML verbatim, which imports clean and
resolves `ZIM:1 -> MOD-CT-07`.

- `scripts/validate_skills.py` — 4/4
- `scripts/validate_examples.py` tier 1 — 7/7, 37 artefacts
- `scripts/test_hooks.py` — 0 failures

Manifest unchanged: 20 skills / 9 hook commands / 4 agents.

Refs #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY
