### PR TITLE
release: 1.8.8 — where a Z-segment sits in the schema definition is the path grammar

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.7"
+    "version": "1.8.8"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.7",
+      "version": "1.8.8",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Version bump only — the content landed in #139.

## What's in it

One skill change since 1.8.7, and it came out of a **measurement** defect rather than a measured one.

`HL7SCH-BUILD-01` had never passed — 20 runs, 0 passed, across three CLIs and two plugin versions —
and was filed here as "the custom schema category is never registered, and loading the skill does not
fix it" (#138). It is overwhelmingly an oracle defect: the check hardcodes
`Parameter SCHEMACATEGORY = "IMGX_2.5"` while the prompt pins only the package name `ImgLink`, and
**3 of 3** runs named their category `ImgLink_2.5`, following this skill's own `MyApp_2.5`
convention. Lifting a scored-**0** run's schema XML verbatim out of its workspace and importing it on
live IRIS 2026.1 gives `cat=[ImgLink_2.5]` and `ZIM:1 -> MOD-CT-07`. The deliverable was right; the
assertion was grading an unstated string. **That half is routed to the testsuite and is not fixed
here** — #138 stays open for it.

### hl7-schemas (#138 → #139)

Placement in the `definition` string **is** the path grammar, not just a validity rule:

| placement | path that reads field 1 |
|---|---|
| top level | `ZAL:1` |
| inside the repeating order group | `PIDgrpgrp(1).ORCgrp(1).ZAL(1):1` |

Both nested traps are silent and one is actively misleading — plain `ZAL:1` under the nested form
fails with `<Ens>ErrGeneral: No segment found at path 'ZAL'`, the **same** error a missing category
produces, so a schema that imported perfectly reads as one that never imported at all. In a DTL an
unresolvable source path is not a compile error, so the symptom is an empty target property. One of
the three runs hit exactly this.

## Compatibility

**No description changes since 1.8.7.** All skill frontmatter is byte-identical, so eval cells
pinned at 1.8.7 remain valid for every skill.

**Known, deliberately not fixed here:** both manifest descriptions say "Ships 8 hooks" and there are
9 hook commands. Correcting it edits text the router matches on, which this repo has measured needs
a before/after (#126, #127) — it does not ride along in a version bump.

## Verified

Live IRIS 2026.1 (Build 235U) via `iris-interop-dev` 0.13.0 — both placements executed rather than
reasoned about.

- `validate_skills.py` 4/4 · `validate_examples.py` tier 1 7/7 · `test_hooks.py` 0 failures
- Both manifests parse; all three version fields at 1.8.8
- Manifest unchanged: 20 skills / 9 hook commands / 4 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY
