### PR TITLE
fix(skills): correct the SqlProc call form and guard it (#141), plus the $GET method trap (#142)

### DIFF
--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -92,6 +92,32 @@ for slug, desc in parsed.items():
 
 check("S4", "every description carries a non-empty trigger list", no_trigger + empty_trigger)
 
+# --- S5: the #141 check. A [SqlProc] projects as <schema>.<Class>_<Method>, where <schema> is the
+# package with dots turned into underscores. `SELECT Pkg_Bootstrap_Method(...)` carries no schema
+# qualifier at all, so IRIS resolves it against SQLUSER and always answers SQLCODE -359. Four skills
+# shipped that form and an eval agent copied one verbatim, so this is a literal-token gate, not a
+# style rule. Two or more underscore-joined identifiers before the paren, with no dot, is the defect.
+SQLPROC_CALL = re.compile(r"SELECT\s+(%?\w+(?:_\w+){2,})\s*\(")
+
+# A line that cites SQLCODE -359 is TEACHING the bad form, not committing it — the router carries
+# both wrong shapes on purpose. Narrow and deliberate: a line that ships the defect and also names
+# its error code would slip through, which is why the exemption is the error code and not a
+# hand-wavier marker like "example" or a fenced-block test.
+TEACHING_THE_FAILURE = re.compile(r"-359\b")
+
+bad_sqlproc = []
+for path in skills:
+    slug = os.path.basename(os.path.dirname(path))
+    for n, line in enumerate(open(path, encoding="utf-8"), 1):
+        if TEACHING_THE_FAILURE.search(line):
+            continue
+        for m in SQLPROC_CALL.finditer(line):
+            bad_sqlproc.append("{}:{}: {} — needs a schema qualifier, e.g. {}".format(
+                slug, n, m.group(1),
+                m.group(1).replace("_", ".", 1)))
+
+check("S5", "no schema-less `SELECT Pkg_Class_Method(...)` SqlProc call (#141)", bad_sqlproc)
+
 print("\n  label space in use (S4 enumerates rather than filters — see #131):")
 for lab, who in sorted(labels.items(), key=lambda kv: -len(kv[1])):
     print("    {:>3}x  {:<16} {}".format(
@@ -107,5 +133,5 @@ if len(labels) > 1:
           "  content must accept every form above; use the S4 regex, never a literal.")
 
 print("\nSkills: {}\n".format(
-    "all {} checks pass".format(4) if not failures else "{} FAILED".format(", ".join(failures))))
+    "all {} checks pass".format(5) if not failures else "{} FAILED".format(", ".join(failures))))
 sys.exit(1 if failures else 0)

--- a/skills/bpl/SKILL.md
+++ b/skills/bpl/SKILL.md
@@ -202,7 +202,8 @@ ClassMethod ValidateProduction(pProductionName As %String) As %String [ SqlProc 
 }
 ```
 
-Invoke via `SELECT MyApp_Bootstrap_ValidateProduction('MyApp.Production')` before every restart. CI step. Test fixture. This catches 90% of the "BP fails with weird error" class of bugs at edit time.
+Invoke via `SELECT MyApp.Bootstrap_ValidateProduction('MyApp.Production')` before every restart
+(schema `MyApp`, function `Bootstrap_ValidateProduction` — see the `interop` router for the rule). CI step. Test fixture. This catches 90% of the "BP fails with weird error" class of bugs at edit time.
 
 For multi-router productions, extend step 2 to iterate every `EnsLib.MsgRouter.RoutingEngine` item (drop the `TOP 1`) and concatenate the results. The string-scan parser is good enough for `<send>` extraction (rule XData uses a stable shape) — replace with `%XML.TextReader` only if you start tracking `<assign>` or `<switch>` activities.
 

--- a/skills/business-services/SKILL.md
+++ b/skills/business-services/SKILL.md
@@ -268,7 +268,8 @@ ClassMethod GenerateRecordMap(pRM As %String) As %String [ SqlProc ]
 }
 ```
 
-Invoke with `SELECT Pkg_Bootstrap_GenerateRecordMap('Pkg.RecordMap.X')`. Notes:
+Invoke with `SELECT Pkg.Bootstrap_GenerateRecordMap('Pkg.RecordMap.X')` — schema `Pkg`, function
+`Bootstrap_GenerateRecordMap`. Notes:
 - `GenerateObject` errors `#5768 Class already exists` if the `.Record` already exists — delete it first, then regenerate.
 - **`GetObject` lives on the RecordMap class, not on `.Record`.** Verifying with
   `##class(Pkg.RecordMap.X.Record).GetObject(...)` raises the same `<METHOD DOES NOT EXIST>` as

--- a/skills/hl7-schemas/SKILL.md
+++ b/skills/hl7-schemas/SKILL.md
@@ -151,6 +151,10 @@ Set tSC = $$$OK
 Write msg.GetValueAt("ZAL:1", , .tSC), " ", $System.Status.GetErrorText(tSC), !
 ```
 
+Do **not** write `$G(msg.GetValueAt("ZAL:1"))` to be safe here — `$GET` forces property syntax, so it
+fails with `<PROPERTY DOES NOT EXIST> GetValueAt` on a method that works unwrapped. Guard the object
+(`$IsObject`) instead; see `message-search-debug`.
+
 Prefer top-level placement for a trailing Z-segment unless the partner's own
 specification genuinely nests it — the path stays short, and DTL authors in the visual
 editor get `ZAL:…` rather than a four-part group path.

--- a/skills/interop/SKILL.md
+++ b/skills/interop/SKILL.md
@@ -139,6 +139,35 @@ A class `Demo.Enc.Encounter` carrying `SqlTableName = "PatEncounter"` projects a
 derivable from the class definition's names alone. Derive nothing; confirm with `iris_table_info`.
 On `SQLCODE -30` (Table not found), the next call is introspection — never another guessed name.
 
+### Calling a `[SqlProc]` — the name is not the class name
+
+A `[SqlProc]` class method projects as **`<package, dots→underscores>.<Class>_<Method>`**: everything
+up to the *last* dot becomes the SQL schema, then the final class name and the method name join with
+an underscore. Measured against `INFORMATION_SCHEMA.ROUTINES` on IRIS 2026.1:
+
+| class :: method | schema | function | call as |
+|---|---|---|---|
+| `Demo.Bootstrap` :: `Ping` | `Demo` | `Bootstrap_Ping` | `SELECT Demo.Bootstrap_Ping(…)` |
+| `ImgLink.HL7.SchemaImport` :: `ImportSchema` | `ImgLink_HL7` | `SchemaImport_ImportSchema` | `SELECT ImgLink_HL7.SchemaImport_ImportSchema(…)` |
+
+The two forms that feel right and are not:
+
+```sql
+SELECT Demo_Bootstrap_Ping('x')   -- -359 'SQLUSER.DEMO_BOOTSTRAP_PING' does not exist
+SELECT Demo.Bootstrap.Ping('x')   -- -359 'DEMO.BOOTSTRAP.PING' does not exist
+```
+
+All-underscores carries no schema qualifier at all, so IRIS resolves it against the default schema
+`SQLUSER` and never finds it. Don't derive the name — read it:
+
+```sql
+SELECT ROUTINE_SCHEMA, ROUTINE_NAME FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_NAME LIKE 'Bootstrap%'
+SELECT parent, Name FROM %Dictionary.CompiledMethod WHERE SqlProc = 1 AND parent %STARTSWITH 'MyApp'
+```
+
+**`-149 <PRIVATE METHOD>` is a different failure and does not look like one.** It means the name
+resolved but the method has no `[SqlProc]` keyword — the fix is on the class, not in the query.
+
 SQL-BO worked flow (child-table projections, invented system catalogs): see `business-operations`
 (section "Resolve real table names BEFORE the first query").
 

--- a/skills/lookup-tables/SKILL.md
+++ b/skills/lookup-tables/SKILL.md
@@ -172,7 +172,9 @@ ClassMethod ImportLookups() As %String [ SqlProc ]
 }
 ```
 
-Invoke from MCP: `SELECT MyApp_Bootstrap_ImportLookups()`. Idempotent because of the prior `DELETE`. Place the SqlProc in your project's `Bootstrap` class so it lives next to other workshop-setup helpers and ships in the same `.cls` file as the rest of the setup.
+Invoke from MCP: `SELECT MyApp.Bootstrap_ImportLookups()` — schema `MyApp`, function
+`Bootstrap_ImportLookups`; the all-underscores form resolves to `SQLUSER` and returns `-359`.
+Idempotent because of the prior `DELETE`. Place the SqlProc in your project's `Bootstrap` class so it lives next to other workshop-setup helpers and ships in the same `.cls` file as the rest of the setup.
 
 **Why a SqlProc rather than a loose `iris_execute` with `&sql`** — and the reason is not the one
 this skill used to give (#119). The inserts **do** persist; what breaks is the error check. The MCP

--- a/skills/message-search-debug/SKILL.md
+++ b/skills/message-search-debug/SKILL.md
@@ -36,6 +36,20 @@ When inspecting a running production through the IRIS MCP, reach for `iris_inter
 
 > **The `<SYNTAX>errdone+2^%qaqqt` signature = you hand-rolled SQL through `iris_execute`.** `%qaqqt` is the SQL query compiler; it chokes on malformed/dynamic SQL (invalid predicates like `%STARTSWITH`/`%LIKE`, or `SELECT … FROM` a table that doesn't exist — `Ens_Config.Setting`, `Config.config`, `%SYS.*ELS*`). Two fixes: (1) a read-only SELECT → use `iris_query` (it goes through a real result-set path and returns a structured failure envelope — branch on its `error_code`; a `hint` naming the right typed tool is usually included but is not guaranteed); (2) anything that runs ObjectScript or **generates classes** → wrap it in a `[SqlProc]` class method and call it via `iris_query`, never embed `&sql`/`%SQL.Statement` inside an `iris_execute` snippet.
 
+> **`<PROPERTY DOES NOT EXIST>` naming a method you know exists = you wrapped the call in `$GET()`.**
+> `$G()` takes a variable or property reference, so `$G(seg.GetValueAt("1"))` makes IRIS resolve
+> `GetValueAt` as a *property* and fail — while `seg.GetValueAt("1")` on the line above works. The
+> error is anti-diagnostic: it sends you hunting for a method name that was already right. **Guard
+> the object, not the call.**
+>
+> ```objectscript
+> Set tVal = ""
+> If $IsObject(seg) { Set tVal = seg.GetValueAt("1") }   // not $G(seg.GetValueAt("1"))
+> ```
+>
+> With a by-reference argument (`$G(m.GetValueAt(p,m.Separators,.sc))`) the same mistake surfaces as
+> `<SYNTAX>` instead, which looks like a typo rather than a category error.
+
 > **Always pass `namespace`.** It is documented as optional on these tools and it is not: it
 > resolves `Ens.Director` / `Ens_Config.*` in whatever namespace the connection defaults to, and if
 > that one is not interop-enabled the call dies with an error that never names the cause —

--- a/skills/unit-tests/SKILL.md
+++ b/skills/unit-tests/SKILL.md
@@ -115,7 +115,7 @@ assert-scanning form reported `passed=2 failed=0` on the same class.
 Invoke from MCP:
 
 ```sql
-SELECT MyApp_Bootstrap_RunTestClass('MyApp.Tests.DT.Censo2Menus')
+SELECT MyApp.Bootstrap_RunTestClass('MyApp.Tests.DT.Censo2Menus')
 ```
 
 ### Qualifier syntax pitfall — booleans only


### PR DESCRIPTION
Both found by analysing the 25 most recent eval runs — 819 MCP calls in the codex arm, 63 failing.
Neither was a model error.

## #141 — four skills shipped a call form that cannot resolve

`unit-tests`, `bpl`, `lookup-tables` and `business-services` all showed
`SELECT Pkg_Bootstrap_Method(...)`. No schema qualifier, so IRIS resolves it against the default
schema `SQLUSER` and answers `SQLCODE -359` every time. `hl7-schemas:191` was already correct and is
untouched.

The rule, measured against `INFORMATION_SCHEMA.ROUTINES` on IRIS 2026.1: a `[SqlProc]` projects as
**`<package, dots→underscores>.<Class>_<Method>`**. I compiled a throwaway
`Demo.Bootstrap::Ping [SqlProc]` and called it three ways:

```
SELECT Demo.Bootstrap_Ping('x')  ->  pong:x
SELECT Demo_Bootstrap_Ping('x')  ->  -359 'SQLUSER.DEMO_BOOTSTRAP_PING' does not exist
SELECT Demo.Bootstrap.Ping('x')  ->  -359 'DEMO.BOOTSTRAP.PING' does not exist
```

Complete separation. **An agent copied `business-services:271` verbatim** in
`r-20260831T140050Z-0efe0a` and burned four round-trips without ever trying the working form; 14 of
15 `iris_query` failures in the batch are this one shape.

The router now states the rule once with the discovery queries, and notes that `-149
<PRIVATE METHOD>` is the other half — the name resolved, the method lacks `[SqlProc]`.

### The guard, verified in both directions

`S5` in `validate_skills.py`. Lines citing `-359` are exempt, because the router teaches both wrong
shapes on purpose — a deliberately narrow exemption, noted in the code as such.

| tree | exit | S5 |
|---|---:|---|
| this branch | 0 | `ok` |
| with `bpl:205` reverted to the bad form | 1 | `FAIL — bpl:205: MyApp_Bootstrap_ValidateProduction — needs a schema qualifier, e.g. MyApp.Bootstrap_ValidateProduction` |
| restored | 0 | `ok` |

A check that has never been shown to fail is not a check, so it is shown here.

## #142 — `$G()` around a method call

`$GET` takes a variable or property reference, so `$G(seg.GetValueAt("1"))` makes IRIS resolve
`GetValueAt` as a *property* and fail — while `seg.GetValueAt("1")` on the line above works. The
error names a method that exists, sending the reader hunting for a name that was already right.

Every `iris_execute` call in the batch wrapping a method in `$G()` failed: **3 of 3, 0 succeeded**.
One surfaces as `<SYNTAX>` rather than `<PROPERTY DOES NOT EXIST>` when a by-reference argument is
involved, which looks like a typo instead of a category error.

Added to `message-search-debug` as an error-signature callout — guard the **object** with
`$IsObject`, not the call — and cross-referenced from `hl7-schemas`, where the failing reads were.

## Compatibility

**No description changes.** All 20 frontmatter blocks byte-identical (verified per-file), so eval
cells pinned at 1.8.8 stay valid.

## Verified

- `validate_skills.py` 5/5 · `validate_examples.py` tier 1 7/7 · `test_hooks.py` 0 failures
- Live IRIS 2026.1 Build 235U via `iris-interop-dev` 0.13.0 — the projection rule and all three call
  forms executed, not reasoned about

Closes #141
Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY
