### PR TITLE
release: 1.8.9 — a SqlProc call form that could never resolve, and a $GET that hides a working method

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.8"
+    "version": "1.8.9"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.8",
+      "version": "1.8.9",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.8",
+  "version": "1.8.9",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Version bump only — content landed in #143.

## What's in it

Both defects came from analysing the 25 most recent eval runs (819 MCP calls in the codex arm, 63
failing). Neither was a model error, and one was **ours being copied faithfully**.

### #141 — `SELECT Pkg_Bootstrap_Method(...)` can never resolve

Four skills shipped it. No schema qualifier, so IRIS resolves against `SQLUSER` and answers
`SQLCODE -359` every time. An agent copied `business-services:271` verbatim in
`r-20260831T140050Z-0efe0a` and burned four round-trips without trying the working form. **14 of 15
`iris_query` failures in the batch are this one shape.**

Measured against `INFORMATION_SCHEMA.ROUTINES` — a `[SqlProc]` projects as
`<package, dots→underscores>.<Class>_<Method>`:

```
SELECT Demo.Bootstrap_Ping('x')  ->  pong:x
SELECT Demo_Bootstrap_Ping('x')  ->  -359 'SQLUSER.DEMO_BOOTSTRAP_PING'
SELECT Demo.Bootstrap.Ping('x')  ->  -359 'DEMO.BOOTSTRAP.PING'
```

`hl7-schemas:191` was already correct and is untouched.

### #142 — `$G()` around a method call

`$GET` forces property syntax, so `$G(seg.GetValueAt("1"))` fails as `<PROPERTY DOES NOT EXIST>` on
a method that works unwrapped. **3 of 3 such calls in the batch failed, 0 succeeded.** With a
by-reference argument it surfaces as `<SYNTAX>` instead — a category error dressed as a typo.

### The guard, shown failing

`S5` in `validate_skills.py`:

| tree | exit | S5 |
|---|---:|---|
| this branch | 0 | `ok` |
| `bpl:205` reverted to the bad form | 1 | `FAIL — bpl:205 … needs a schema qualifier, e.g. MyApp.Bootstrap_ValidateProduction` |
| restored | 0 | `ok` |

## Compatibility

**No description changes since 1.8.8.** All 20 frontmatter blocks byte-identical, verified per file —
eval cells pinned at 1.8.8 remain valid for every skill.

## Prediction on record

#141 carries a falsifiable claim made *before* the measurement: `iris_query`'s failure rate on a
comparable codex arm should fall from **32% (15/46) to ~2% (1/46)**, the survivor being a genuinely
guessed column. Raw counts to be reported alongside the rate, since a fix that also reduces how often
`iris_query` is called moves the denominator with the numerator.

## Not in this release

**#144**, filed from the same batch: agents unit-test a Business Operation by `%New()`-ing it, which
cannot work — `Ens.BusinessOperation` does not declare `%New`, a subclass returns `""`, and the
failure surfaces later as `<INVALID OREF>` while the adapter next to it instantiates fine.

## Verified

- `validate_skills.py` 5/5 · `validate_examples.py` tier 1 7/7 · `test_hooks.py` 0 failures
- Both manifests parse; all three version fields at 1.8.9
- Live IRIS 2026.1 Build 235U via `iris-interop-dev` 0.13.0
- Manifest unchanged: 20 skills / 9 hook commands / 4 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY
