### PR TITLE
docs(tdd): a Business Service/Operation does not instantiate (#144)

### DIFF
--- a/skills/business-operations/SKILL.md
+++ b/skills/business-operations/SKILL.md
@@ -153,6 +153,7 @@ Switch to UPSERT (`INSERT ... ON CONFLICT (paciente_id) DO NOTHING` / `DO UPDATE
 
 ## Common pitfalls
 
+- **`##class(Pkg.BO.X).%New()` to test the operation directly** → a BO does not instantiate. `Ens.BusinessOperation` declares no `%New`; a subclass returns `""`, and the error surfaces a line later as `<INVALID OREF>`. The adapter beside it *does* instantiate, which makes the BO look like the broken one. See `tdd` §"Pitfalls specific to Interop TDD".
 - **Concatenating values into SQL strings** instead of parameterizing → injection + escaping bugs.
 - **Writing SQL from an assumed table name, then guessing again on `-30`** → see §"Resolve real table names BEFORE the first query" above.
 - **Forgetting `MessageMap`** → every request hits the default `OnMessage` method which then has to dispatch by type manually.

--- a/skills/business-services/SKILL.md
+++ b/skills/business-services/SKILL.md
@@ -123,6 +123,7 @@ The user-stated principle: a BS that needs a setting should refuse to start if t
 
 ## Common pitfalls
 
+- **`##class(Pkg.BS.X).%New()` to test the service directly** → a BS does not instantiate. `Ens.BusinessService` declares no `%New`; a subclass returns `""`, and the error surfaces a line later as `<INVALID OREF>`. See `tdd` §"Pitfalls specific to Interop TDD".
 - **One BS handling multiple HL7 schema versions** → not allowed; each BS is one schema. Create separate BSes for v2.3 and v2.5.
 - **Hand-rolled CSV parser** → use Record Mapper. Hand-rolled parsing fails on quoted fields, embedded delimiters, encoding edge cases.
 - **Sending Sync when Async would do** → blocks pool slots, kills throughput.

--- a/skills/message-search-debug/SKILL.md
+++ b/skills/message-search-debug/SKILL.md
@@ -50,6 +50,11 @@ When inspecting a running production through the IRIS MCP, reach for `iris_inter
 > With a by-reference argument (`$G(m.GetValueAt(p,m.Separators,.sc))`) the same mistake surfaces as
 > `<SYNTAX>` instead, which looks like a typo rather than a category error.
 
+> **`<METHOD DOES NOT EXIST>` on a stream = you reached for the `%File` API.** `%Stream.FileCharacter`
+> has **no `Open()` and no `Save()`** — those are `%File` and `%Save` respectively. Verified on IRIS
+> 2026.1: `.Open()` and `.Save()` both abort; `.LinkToFile()` and `.%Save()` are the real members.
+> The class instantiates fine with `%New()`, so the failure lands on the second line, not the first.
+
 > **Always pass `namespace`.** It is documented as optional on these tools and it is not: it
 > resolves `Ens.Director` / `Ens_Config.*` in whatever namespace the connection defaults to, and if
 > that one is not interop-enabled the call dies with an error that never names the cause —

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -443,6 +443,15 @@ See `business-operations` and `bpl` for the runtime side of the same rule.
 
 - **Extending `%UnitTest.TestCase` instead of `%UnitTest.TestProduction`** — you lose everything the superclass provides and reinvent it by hand. Nor is `%UnitTest.TestCase` an escape hatch for a compile error: `Extends %UnitTest.TestProduction` and `Parameter PRODUCTION` are fixed points — fix the error, never remove the parameter or change the superclass to silence it. See §"Baseline class" above.
 - **Omitting `Parameter PRODUCTION` (or leaving it `= ""`)** — `#5001` at compile time; the class never exists to any runner. See §"Required parameters" above.
+- **`%New()`-ing a Business Service or Operation to test it directly — it does not instantiate.** The cheap move from conventional software is to new the host up and call `OnMessage()` with a request. It cannot work: `Ens.BusinessOperation` and `Ens.BusinessService` do not declare `%New`, and a concrete subclass returns `""` rather than erroring — so the failure arrives a line later, as `<INVALID OREF>` that never mentions the host. Measured on IRIS 2026.1:
+
+  | `##class(…).%New()` | result |
+  |---|---|
+  | `Ens.BusinessOperation`, `Ens.BusinessService` | `<METHOD DOES NOT EXIST>` |
+  | `Ens.BusinessProcess` | returns `""` — `$IsObject` = 0, no error |
+  | `EnsLib.File.OutboundAdapter` and other adapters | a real object, `$IsObject` = 1 |
+
+  **The adapter instantiating is the trap.** `ad=1` printed beside `bo=0` reads as "objects work here, so my class is broken", and sends you to re-inspect the one thing that was fine. A BS/BO is exercised only by the production framework: run it through `%UnitTest.TestProduction` + `iris_test`, or send it a message with the `deploy-smoke-test` agent. If you want to unit-test logic in isolation, put that logic in a plain `%RegisteredObject` helper the host delegates to, and test the helper.
 - **Stubbing the adapter in BO tests.** In conventional software you'd unit-test the BO method with a mocked adapter — in IRIS Interop that's an anti-pattern. The adapter boundary is exactly where the defects you care about live (auth, classpath, type marshalling, encoding, timeouts). Stubs make the test green while the real thing breaks. Use a real adapter against a real test endpoint.
 - **Forgetting to override `TestControl()`** — TestProduction will start/stop your production every time you `Run()`. Override to no-op when the production is managed externally.
 - **Forgetting to seed `..BaseLogId`** — `GetEventLog` returns nothing if `BaseLogId` is empty. Seed it in `OnBeforeAllTests` from `MAX(ID) FROM Ens_Util.Log`.


### PR DESCRIPTION
Five of the 26 `iris_execute` failures in the latest codex batch are one mechanism: the agent tried
to test a Business Operation by `%New()`-ing it and calling `OnMessage()` directly. All five end in
`<INVALID OREF>`, and all four scenarios were ones where the agent was trying to **prove its
component worked**. This is the failure mode of diligence, not of laziness.

## Measured on IRIS 2026.1 Build 235U

| `##class(…).%New()` | result |
|---|---|
| `Ens.BusinessOperation`, `Ens.BusinessService` | `<METHOD DOES NOT EXIST>` |
| `Ens.BusinessProcess` | returns `""` — `$IsObject` = 0, no error |
| `EnsLib.File.OutboundAdapter` | `$IsObject` = 1 |
| `%Stream.FileCharacter` | `$IsObject` = 1 |

The base classes do not declare `%New` at all; a concrete subclass returns `""` rather than erroring,
so the failure arrives a line later as `<INVALID OREF>` that never names the host.

## The adapter is the trap

The agents' own probes printed the answer and it was unreadable:

```objectscript
Set bo=##class(ResultOut.BO.ArchiveWriter).%New()   Write "bo=", $IsObject(bo), !   // bo=0
Set ad=##class(EnsLib.File.OutboundAdapter).%New()  Write "ad=", $IsObject(ad), !   // ad=1
Set bo.Adapter=ad                                                                   // <INVALID OREF>
```

One success beside one failure reads as *"objects work here, so my class is broken"* — and sends the
reader to re-inspect the thing that was fine. A correct positive control there would have been
`%New()` on another `Ens.Business*` class: adjacent in **mechanism**, not adjacent in the code.

## What this adds

`tdd`'s pitfall list gets the table and the three real options — run it through
`%UnitTest.TestProduction` + `iris_test`, send it a message with the `deploy-smoke-test` agent, or
move the logic into a plain `%RegisteredObject` helper and test that. One-line cross-references from
`business-operations` and `business-services`.

Plus the smaller trap from the same batch (3 of the 5 "guessed a member name" failures):
`%Stream.FileCharacter` has **no `Open()` and no `Save()`** — those are `%File` and `%Save`. It *does*
instantiate, so the failure lands on the second line. Recorded as an error-signature callout in
`message-search-debug` beside the `$GET` one.

## No S6 guard, deliberately

S5 gates a token this repo actually shipped wrong. **No skill has ever shown `%New()` on a BS/BO**, so
a guard here would fire only on the anti-pattern citations this PR adds, and would need an exemption
to stay green. A check whose only matches are the prose describing it is not evidence of anything.
Worth revisiting if a real instance ever lands.

## Compatibility

**No description changes.** All 20 frontmatter blocks byte-identical, verified per file.

## Verified

- `validate_skills.py` 5/5 · `validate_examples.py` tier 1 7/7 · `test_hooks.py` 0 failures
- Live IRIS 2026.1 Build 235U via `iris-interop-dev` 0.13.0 — every row of the table executed

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY
