### PR TITLE
release: 1.8.10 — a Business Service/Operation does not instantiate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.9"
+    "version": "1.8.10"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.9",
+      "version": "1.8.10",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.9",
+  "version": "1.8.10",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Version bump only — content landed in #146.

## What's in it

One change since 1.8.9, and like 1.8.9's it came from grouping eval failures by **mechanism** rather
than by error signal. By signal these five scatter into two unrelated buckets — two as
`<METHOD DOES NOT EXIST>`, three as `<INVALID OREF>` — with the smaller half sitting in the
honest-model-error pile. They are one cause.

### #144 — a BS/BO cannot be instantiated

| `##class(…).%New()` | result |
|---|---|
| `Ens.BusinessOperation`, `Ens.BusinessService` | `<METHOD DOES NOT EXIST>` |
| `Ens.BusinessProcess` | returns `""` — `$IsObject` = 0, no error |
| `EnsLib.File.OutboundAdapter` | `$IsObject` = 1 |
| `%Stream.FileCharacter` | `$IsObject` = 1 |

The base classes don't declare `%New`; a subclass returns `""` rather than erroring, so the failure
lands a line later as `<INVALID OREF>` that never names the host. **The adapter instantiating beside
it is the trap** — the agents' own probes printed `bo=0 ad=1`, and one success next to one failure
reads as "objects work here, so my class is broken". All four scenarios involved were ones where the
agent was trying to *prove* its component worked.

`tdd` gets the table and the three real options; one-line cross-references from
`business-operations` and `business-services`. Plus `%Stream.FileCharacter` has no `Open()`/`Save()`
(those are `%File`/`%Save`) and *does* instantiate, so that one fails on the second line —
recorded in `message-search-debug`.

## No new validator check, deliberately

`S5` exists because this repo shipped a wrong token. No skill has ever shown `%New()` on a BS/BO, so
a guard would fire only on the anti-pattern prose #146 adds and would need an exemption to stay
green. A check whose only matches are the text describing it is not evidence of anything.

## Compatibility

**No description changes since 1.8.8 — three releases running.** All 20 frontmatter blocks
byte-identical, verified per file. 1.8.8 / 1.8.9 / 1.8.10 differ only in skill bodies, so eval cells
pinned at 1.8.8 stay valid for every skill.

## Still open, and not fixable here

- **#128, #127** — need measurement arms rather than edits; #127 touches description text, which this
  repo has measured needs a before/after.
- **#115** — a tracking record by construction: *"nothing here changes a hook."*
- **#102** — an eval arm-build whose 1.8.4 target has been unmaterialisable since 2026-08-29.

## Verified

- `validate_skills.py` 5/5 · `validate_examples.py` tier 1 7/7 · `test_hooks.py` 0 failures
- Both manifests parse; all three version fields at 1.8.10
- Live IRIS 2026.1 Build 235U via `iris-interop-dev` 0.13.0
- Manifest unchanged: 20 skills / 9 hook commands / 4 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY
