### PR TITLE
release: 1.8.11 — TestControl asserts nothing, and prose in a description is a tax

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.10"
+    "version": "1.8.11"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.10",
+      "version": "1.8.11",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.10",
+  "version": "1.8.11",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Version bump only — content landed in #149.

## #148 — `TestControl` is a liveness probe, not a control

`tdd` shows the no-op override in five places and never said what its passing does not mean. It is the first method in every skeleton, named `TestControl`, and passes unconditionally — so in a results table it reads like a control. The testsuite session had quoted "TestControl 73/73" as evidence an oracle was healthy; the same framing was used against this repo on `HL7SCH-BUILD-01`, where the oracle **was** the defect. One pitfall bullet keeping both halves: a liveness signal, never a correctness one. No skeleton changes.

## #127 — the open question, answered from data already on disk

The arm the issue asked for had already been run and was never analysed for the positive direction.

| cell | `ALERT-NEG-01` | `ALERT-FIRE-01` |
|---|---|---|
| control | 90.3% | 90.3% |
| +60 PROSE | **77.0%** | **91.0%** |
| +60 TRIGGERS | 92.0% | 94.0% |

Recall +0.7 pt (p=1.000) against precision −13.3 pt (p=0.006). **Tax, not dial.** The pre-registered ceiling caveat is honoured: +0.7 pt with ~10 points of headroom is nothing, and the TRIGGERS cell moved +3.7 pt showing the metric can rise — at p=0.343, weakening the objection without eliminating it.

Recorded as an authoring convention in `CLAUDE.md`. **Licenses not-adding, not shortening** — the probe measured adding 60 words; removal symmetry is untested.

## Compatibility

**Zero `description:` lines changed**, all 20 frontmatter blocks byte-identical — four releases running since 1.8.8, so cells pinned at 1.8.8 remain valid.

## Verified
- `validate_skills.py` 5/5 · `validate_examples.py` tier 1 7/7 · `test_hooks.py` 0 failures
- Both manifests parse; all three version fields at 1.8.11
- Manifest unchanged: 20 skills / 9 hook commands / 4 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY