### PR TITLE
docs: mutation as the vacuity detector, baseline + fresh-run rules, and S5's coverage (#151)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,8 @@ sibling skill for each task. Always load `iris-interop-skills:tdd` as a companio
   **This licenses not-adding, not shortening**: the probe measured *adding* 60 words, and whether
   removing words is symmetric is untested. Existing descriptions stay as they are until an arm
   measures the removal direction, and any description edit still needs a before/after (#126, #127).
+- **A grep gate guards a spelling, not the rule it is named after — say so at the gate** (#151).
+  Verifying a home-grown check in both directions (S5 was) proves that one known-bad input reaches
+  its failure path. It does not prove the check recognises every violation of the constraint. Where
+  the gate is narrower than the rule, write the gap next to the check, so a clean run cannot be read
+  as coverage it does not have.

--- a/scripts/validate_skills.py
+++ b/scripts/validate_skills.py
@@ -118,6 +118,14 @@ for path in skills:
 
 check("S5", "no schema-less `SELECT Pkg_Class_Method(...)` SqlProc call (#141)", bad_sqlproc)
 
+# COVERAGE OF S5, stated here because a clean run reads like more than it is. This gate guards a
+# SPELLING in skill text; it does not guard the rule "a [SqlProc] call resolves". It cannot see a
+# wrong schema prefix, a name assembled at runtime, or a method that never got the [SqlProc]
+# keyword (-149). Verifying it in both directions — done, and it named bpl:205 when the defect was
+# reintroduced — proves one known-bad input reaches its failure path; it does not prove the check
+# recognises every violation of the constraint it is named after. S5 green == no skill DOCUMENTS
+# the -359 form. It is NOT evidence that any call in the corpus resolves.
+
 print("\n  label space in use (S4 enumerates rather than filters — see #131):")
 for lab, who in sorted(labels.items(), key=lambda kv: -len(kv[1])):
     print("    {:>3}x  {:<16} {}".format(

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -100,6 +100,16 @@ namespace and the compiler result was read, and (b) its `%UnitTest.TestProductio
 via `iris_test`. Files on local disk are a scaffold, not a deliverable. Do not write a completion
 summary unless both happened in this session; if either is missing, say plainly which one and stop.
 
+Two rules about the numbers you quote for (b):
+
+- **They come from one final run, made after the last edit.** A green from earlier in the task went
+  stale the moment you recompiled — it measured a class that no longer exists. Never assemble one
+  result out of several runs.
+- **Record the baseline first, then hold at zero NEW failures.** Where the namespace already has red
+  tests, capture which ones fail *before* you start, verbatim. Green then means *no new failure*,
+  not an empty list — and repairing an unrelated pre-existing failure is scope creep: surface it,
+  don't quietly fix it.
+
 Stepping over 1-2-3 ("just write the DTL first") is the most common anti-pattern. Refuse it:
 
 > "I'll write the test first. It defines what 'done' means, and we'll know we're done when it passes."
@@ -145,6 +155,24 @@ against an implementation that silently drops every field.
 Write assertions only with macros that exist — there is no `$$$AssertNotNull` or `$$$AssertGreater`,
 and inventing one fails the compile with `MPP5610`. Mechanism: see `unit-tests` (section "Assertion
 macros — the inventory").
+
+### The checklist says what to write — one mutation says whether it worked
+
+A class can satisfy all five rows and still assert nothing that matters, and no amount of *reading*
+it tells you which. The detector is to break the implementation on purpose and watch the suite go
+red:
+
+1. Pick the logic carrying the most weight in what you just wrote.
+2. Introduce ONE plausible bug — flip a comparison, delete an `<assign>` from the DTL, remove a
+   `<when>` from the rule, return a constant from the BO method.
+3. `iris_compile`, then `iris_test` the same class. **It must fail** — and read *which* `Test*`
+   method failed. A mutant killed by an unrelated test says nothing about the behaviour you meant
+   to check.
+4. Restore the source, `iris_compile`, `iris_test`: green again before you continue.
+
+Three to five mutants is a normal pass; one is far better than none. A survivor is not a mutation
+problem, it is a missing assertion — add the test that kills it. Never skip step 4: an unrestored
+mutant sitting compiled in the namespace looks exactly like a component that was never built.
 
 ## What's testable in IRIS Interop — decision table
 


### PR DESCRIPTION
Closes #151.

Body text only. **No frontmatter touched** — all 20 blocks byte-identical to `v1.8.11`, so eval cells pinned at 1.8.8 stay valid.

Derived from reviewing [AmazingAng/old-coder](https://github.com/AmazingAng/old-coder) (MIT) against our `tdd`. Most of it does not transfer; three things do.

### `tdd` — mutation, ~14 lines

The completeness checklist tells the *author* what to write; nothing executes it. A class can satisfy all five rows, look healthy on assertion density, and assert nothing that matters — the shape already measured here (67/103 green on first run, 5.3 methods / 2.8 asserts each).

Mutation is the detector, and it needs no new dependency: `iris_compile` + `iris_test` already ship. Break the logic on purpose → expect red → restore → re-green.

Two details are load-bearing:
- **step 3 reads *which* `Test*` method failed** — a mutant killed by an unrelated test says nothing about the behaviour under check;
- **step 4 is not optional.** old-coder's own demo had a hand-rolled runner report kills for mutants it never executed (shared bytecode cache). That defect can only *inflate* a score, so it never surfaces red — same family as #148's `TestControl`.

### `tdd` — which run the numbers come from, ~8 lines

Definition of Done required compile-read + green suite *in this session*, but did not forbid quoting a green from before the last edit and said nothing about a namespace with pre-existing red tests. Now: one final run after the last edit; record the baseline and hold at **zero NEW** failures.

### S5's coverage — `validate_skills.py` + `CLAUDE.md`

S5 (#141) was verified in both directions and named `bpl:205` on reintroduction. True — and narrower than the rule it is named after. It greps skill *text* for `SELECT Pkg_Class_Method(`; it cannot see a wrong schema prefix, a runtime-assembled name, or a missing `[SqlProc]` keyword (`-149`). **S5 green means no skill *documents* the -359 form. It is not evidence that any call resolves.** Stated at the gate, generalised in CLAUDE.md.

### Deliberately not taken

EVIDENCE artifact + SPEC-approval gate (`conformance-review` and the Stop gate hold that slot), tier calibration (this domain is uniformly high-stakes), property-based tests (no ObjectScript library), changed-line coverage (no coverage tool verified reachable through our MCP surface).

### Verification

| check | result |
|---|---|
| `validate_skills` | exit 0, all 5 checks |
| **S5 positive control** | defect reintroduced → exit 1 naming `bpl:205`; restored → exit 0, `git diff` clean |
| `validate_examples` | exit 0, 37 artefacts / 34 classes, tier 1 all 7 |
| `test_hooks` | exit 0, 0 failures |
| frontmatter | all 20 blocks byte-identical to `v1.8.11` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY