### PR TITLE
docs: the mutation pass runs once per component, and its size is set by whether RED was watched (#153)

### DIFF
--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -160,7 +160,7 @@ macros — the inventory").
 
 A class can satisfy all five rows and still assert nothing that matters, and no amount of *reading*
 it tells you which. The detector is to break the implementation on purpose and watch the suite go
-red:
+red — **once per component, after the whole suite is green**, never inside the per-behaviour loop:
 
 1. Pick the logic carrying the most weight in what you just wrote.
 2. Introduce ONE plausible bug — flip a comparison, delete an `<assign>` from the DTL, remove a
@@ -170,9 +170,16 @@ red:
    to check.
 4. Restore the source, `iris_compile`, `iris_test`: green again before you continue.
 
-Three to five mutants is a normal pass; one is far better than none. A survivor is not a mutation
-problem, it is a missing assertion — add the test that kills it. Never skip step 4: an unrestored
-mutant sitting compiled in the namespace looks exactly like a component that was never built.
+**How many is decided by whether you watched RED, not by taste.** A mutation and an observed RED are
+the same proof at two different times — a test you saw fail before the code existed has already
+proven it can fail. So: **one** mutant by default, spot-checking logic that arrived during
+GREEN/REFACTOR with no test driving it. **Three to five** where the class was green on its first
+run, because there the RED proof was never taken and this is the only detector left.
+
+Budget it honestly: a mutant is three MCP calls and the restore three more — six for the default
+pass, eighteen for the full one. A survivor is not a mutation problem, it is a missing assertion —
+add the test that kills it. Never skip step 4: an unrestored mutant sitting compiled in the
+namespace looks exactly like a component that was never built.
 
 ## What's testable in IRIS Interop — decision table
 


### PR DESCRIPTION
Closes #153. Follow-up to #151 / PR #152, raised by the user within the hour of shipping 1.8.12.

Body text only, `skills/tdd/SKILL.md` alone, **+11 −4**. No frontmatter touched — all 20 blocks byte-identical to `v1.8.12`.

### Frequency — the real hazard

The block sat after the completeness checklist, which *reads* as end-of-component, but nothing said so. Read as part of the per-behaviour RED→GREEN→REFACTOR loop it runs 4–6 times per component. Now explicit: **once per component, after the whole suite is green.**

### Count — flat "three to five" ignored what the build already proved

A mutant can't be batched (apply two and the kill is unattributable), so the cost is mechanical:

| pass | calls |
|---|---|
| 1 mutant | 3 + 3 restore = **6** |
| 5 mutants | 15 + 3 restore = **18** |

Against ≈18 calls/run from a one-batch transcript parse, the old wording asked for roughly a doubling of a component's MCP traffic.

**The calibration:** a mutation and an observed RED are the same proof at two different times. A test watched failing before the code existed has already proven it can fail — mutation is the retroactive substitute for a RED never taken. So:

- RED observed per behaviour → **one** mutant, spot-checking logic that arrived during GREEN/REFACTOR with no test driving it;
- class green on its first run (the 65% case the skill already measures) → **3–5**, the only detector left.

The tax lands on builds that skipped the cheap proof and vanishes for builds that didn't.

### Known limit

The 1-vs-3-5 split is a **judgement about proof redundancy, not a measurement**. No arm shows one mutant on a properly-RED-driven class catches materially less than five, and the round-trip figures are arithmetic plus a single-batch parse — not a measured build-time delta. Recorded on #153 as the parameter to measure if mutation ever earns an arm.

### Verification

| check | result |
|---|---|
| `validate_skills` | exit 0, all 5 |
| `validate_examples` | exit 0, 37 artefacts / 34 classes |
| `test_hooks` | exit 0, 0 failures |
| frontmatter | 20/20 byte-identical to `v1.8.12` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY