### PR TITLE
fix: the mutation steps never pushed the mutant to IRIS, so a green suite read as a survivor (#155)

### DIFF
--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -163,12 +163,14 @@ it tells you which. The detector is to break the implementation on purpose and w
 red — **once per component, after the whole suite is green**, never inside the per-behaviour loop:
 
 1. Pick the logic carrying the most weight in what you just wrote.
-2. Introduce ONE plausible bug — flip a comparison, delete an `<assign>` from the DTL, remove a
-   `<when>` from the rule, return a constant from the BO method.
-3. `iris_compile`, then `iris_test` the same class. **It must fail** — and read *which* `Test*`
-   method failed. A mutant killed by an unrelated test says nothing about the behaviour you meant
-   to check.
-4. Restore the source, `iris_compile`, `iris_test`: green again before you continue.
+2. Introduce ONE plausible bug in the source file — flip a comparison, delete an `<assign>` from
+   the DTL, remove a `<when>` from the rule, return a constant from the BO method.
+3. **Push it with `iris_doc(mode=put, compile=true)`.** Editing `src/` does nothing on its own:
+   `iris_compile` takes a class NAME and recompiles what is already in the namespace, so a mutant
+   that was never `put` leaves the original class standing and the suite stays green.
+4. `iris_test` the same class. **It must fail** — and read *which* `Test*` method failed. A mutant
+   killed by an unrelated test says nothing about the behaviour you meant to check.
+5. Restore the source, `iris_doc(mode=put, compile=true)`, `iris_test`: green before you continue.
 
 **How many is decided by whether you watched RED, not by taste.** A mutation and an observed RED are
 the same proof at two different times — a test you saw fail before the code existed has already
@@ -176,10 +178,15 @@ proven it can fail. So: **one** mutant by default, spot-checking logic that arri
 GREEN/REFACTOR with no test driving it. **Three to five** where the class was green on its first
 run, because there the RED proof was never taken and this is the only detector left.
 
-Budget it honestly: a mutant is three MCP calls and the restore three more — six for the default
-pass, eighteen for the full one. A survivor is not a mutation problem, it is a missing assertion —
-add the test that kills it. Never skip step 4: an unrestored mutant sitting compiled in the
-namespace looks exactly like a component that was never built.
+Budget it honestly: with `compile=true` a mutant is two MCP calls and the restore two more — four
+for the default pass, twelve for the full one.
+
+A survivor is a missing assertion — but **confirm the mutant actually landed before calling it
+one.** `iris_doc(mode=get)` and look at the mutated line. A green suite over a `put` that did not
+happen is a result for a mutant that never ran, and on screen it is indistinguishable from a
+genuinely vacuous test — you would then add a test to kill a bug that was never there. Never skip
+the restore either: an unrestored mutant sitting compiled in the namespace looks exactly like a
+component that was never built.
 
 ## What's testable in IRIS Interop — decision table
 


### PR DESCRIPTION
Closes #155. Defect in the block added by #151, missed again by the #153 calibration.

Body text only, `skills/tdd/SKILL.md` alone, **+17 −10**. Frontmatter 20/20 byte-identical to `v1.8.13`.

### The bug

Shipped step 3 was *"`iris_compile`, then `iris_test` the same class."* `iris_compile` takes `target` = a class **name** and recompiles what is already in the namespace — it does not read `src/`. An agent editing the source file and following the steps literally never puts the mutant into IRIS: the original class stands, `iris_test` is green.

The next sentence then said a survivor is a missing assertion, add the test that kills it. So the documented recovery was to **add a test for a bug that was never introduced**, and the class left the pass looking *more* verified than it entered.

Same defect class the 1.8.12 notes describe in old-coder's hand-rolled runner, sign inverted — theirs inflated kills, ours inflated survivors. Both are a result for a mutant that never ran, and both are invisible because the output looks like the output of a working pass.

The correct flow was already in this same skill at line 398. The new block just didn't use it.

### Fix

- Steps 3 and 5 use `iris_doc(mode=put, compile=true)`, with one line on why editing `src/` isn't enough.
- **Enrolment guard before declaring a survivor:** `iris_doc(mode=get)` and read the mutated line.

### Cost correction, downward

`compile=true` folds put+compile into one call, so #153's figures were high:

| pass | published in 1.8.13 | actual |
|---|---|---|
| 1 mutant | 6 | **4** |
| 5 mutants | 18 | **12** |

### Verification

`validate_skills` 0 · `validate_examples` 0 (37 artefacts / 34 classes) · `test_hooks` 0 · frontmatter 20/20 unchanged.

Caught on checking the `iris_compile` tool schema — not by re-reading the text, which I wrote and reviewed twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY