### PR TITLE
fix: a put counts as a write only if it reached IRIS (#157)

### DIFF
--- a/hooks/conformance_stop_gate.py
+++ b/hooks/conformance_stop_gate.py
@@ -273,6 +273,71 @@ def latch_record(transcript, signature):
         pass  # a latch we cannot write costs a repeat, never a crash
 
 
+# --- #157: a put that never reached IRIS is not a write -----------------------
+#
+# The gate used to match on the CALL and never on its outcome, so an
+# iris_doc(mode=put) that src_before_iris.py BLOCKED was counted as a class
+# written into IRIS -- and CR-12's remedy then told the session to create a
+# source file for a class that deliberately does not exist. The correct
+# behaviour (respecting the sibling gate) was punished, and the prescribed fix
+# manufactured the very evidence the gate asks for.
+#
+# Four result shapes appear in real transcripts (37 specimens, 2026-09-03):
+#
+#   A  PreToolUse block   is_error, content is this plugin's own prose
+#                         ("Source-of-truth: ... would exist only in ...")   NOT written
+#   B  MCP refusal        is_error, {"error": "...explicit Storage definition..."}  NOT written
+#   C  compile failed     is_error, {"compile_console": [...], "compile_errors": [...]}
+#                         -> the document IS stored, only the compile was skipped.  WRITTEN
+#   D  success            no is_error, {"open_uri": ..., "storage_stripped": ...}   WRITTEN
+#
+# C is why "is_error means not written" would be wrong: it would switch CR-12 off
+# for orphaned work that really is sitting in the namespace -- turning a false
+# positive into a false negative, which is the failure this criterion exists for.
+#
+# So the test is not "did it error" but "is there positive evidence it never got
+# to IRIS". Anything unrecognised, unparseable, or missing a result still counts,
+# so this can only ever REMOVE a false positive.
+
+# Keys only present once iris_doc has actually written and/or compiled.
+# Matched as JSON KEYS, never as substrings of prose -- a substring gate here
+# would guard a spelling rather than the outcome.
+REACHED_IRIS_KEYS = ("compile_console", "compile_errors", "compiled",
+                     "open_uri", "storage_stripped")
+
+
+def _result_text(block):
+    c = block.get("content")
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        return "\n".join(b["text"] for b in c
+                          if isinstance(b, dict) and isinstance(b.get("text"), str))
+    return ""
+
+
+def put_reached_iris(block):
+    """False only with positive evidence the put never reached the namespace."""
+    if not isinstance(block, dict):
+        return True                       # no result recorded -> unchanged behaviour
+    if not block.get("is_error"):
+        return True                       # D
+    txt = _result_text(block).strip()
+    if not txt:
+        return True
+    try:
+        payload = json.loads(txt)
+    except Exception:
+        return False                      # A -- prose, so nothing was stored
+    if not isinstance(payload, dict):
+        return True
+    if any(k in payload for k in REACHED_IRIS_KEYS):
+        return True                       # C
+    if "error" in payload:
+        return False                      # B
+    return True
+
+
 def put_signature(put):
     return hashlib.sha1("\n".join(sorted(put)).encode("utf-8")).hexdigest()
 
@@ -288,6 +353,7 @@ def scan_transcript(path, cutoff=0.0):
     put, reviewed = set(), False
     files = transcript_set(path)
     opened = 0
+    results, events = {}, []          # #157: correlate each put with its outcome
 
     for fpath in files:
         try:
@@ -310,7 +376,14 @@ def scan_transcript(path, cutoff=0.0):
                 if not isinstance(content, list):
                     continue
                 for block in content:
-                    if not isinstance(block, dict) or block.get("type") != "tool_use":
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") == "tool_result":
+                        rid = block.get("tool_use_id")
+                        if rid:
+                            results[rid] = block
+                        continue
+                    if block.get("type") != "tool_use":
                         continue
                     tool = str(block.get("name") or "")
                     inp = block.get("input") or {}
@@ -333,7 +406,7 @@ def scan_transcript(path, cutoff=0.0):
                             continue
                         if GENERATED.search(name):
                             continue
-                        put.add(strip_cls(name))
+                        events.append(("put", block.get("id"), strip_cls(name)))
 
                     elif mode == "delete":
                         # Staging scratch classes and deleting them afterwards is a legitimate
@@ -342,12 +415,23 @@ def scan_transcript(path, cutoff=0.0):
                         # namespace, and the gate fires on the careful case.
                         for n in ([inp.get("name")] + list(inp.get("names") or [])):
                             if isinstance(n, str) and n.strip():
-                                put.discard(strip_cls(n.strip()))
+                                events.append(("del", None, strip_cls(n.strip())))
+
+    # replay in encounter order so a later delete still cancels an earlier put
+    skipped = 0
+    for kind, tid, cname in events:
+        if kind == "del":
+            put.discard(cname)
+        elif put_reached_iris(results.get(tid)):
+            put.add(cname)
+        else:
+            skipped += 1
 
     if not opened:
         _trace("transcript_unreadable", transcript=path, candidates=len(files))
         return put, True  # cannot read anything -> never block on a hook's blind spot
-    _trace("scanned", transcripts=opened, subagents=len(files) - 1, puts=len(put), reviewed=reviewed)
+    _trace("scanned", transcripts=opened, subagents=len(files) - 1, puts=len(put),
+           blocked_puts=skipped, reviewed=reviewed)
     return put, reviewed
 
 

--- a/scripts/test_hooks.py
+++ b/scripts/test_hooks.py
@@ -104,6 +104,19 @@ def rec(off, tool, inp):
                        "message": {"content": [{"type": "tool_use", "name": tool, "input": inp}]}})
 
 
+def rec_id(off, tool, inp, tuid):
+    return json.dumps({"timestamp": iso(off),
+                       "message": {"content": [{"type": "tool_use", "name": tool,
+                                                "input": inp, "id": tuid}]}})
+
+
+def res(off, tuid, content, is_error=False):
+    b = {"type": "tool_result", "tool_use_id": tuid, "content": content}
+    if is_error:
+        b["is_error"] = True
+    return json.dumps({"timestamp": iso(off), "message": {"content": [b]}})
+
+
 def transcript(lines):
     fd, p = tempfile.mkstemp(suffix=".jsonl")
     with os.fdopen(fd, "w") as fh:
@@ -179,6 +192,44 @@ clear(t)
 check("stop_hook_active short-circuits", "ALLOW", stop(t, work, stop_hook_active=True))
 
 check("unreadable transcript", "ALLOW", stop(transcript(["{not json"]), work))
+
+# --------------------------------------------------------------------------- #157
+# A put that src_before_iris BLOCKED is not a class written into IRIS. The two
+# "must still fire" rows are the load-bearing half: excluding every is_error
+# would turn this false positive into a FALSE NEGATIVE and switch CR-12 off for
+# exactly the orphaned work it exists to catch. Bodies are the real shapes taken
+# from 37 transcript specimens, not invented ones.
+print("\n#157  conformance_stop_gate — a put counts only if it reached IRIS")
+print("  {:<38}{:<16}{:<16}{}".format("case", "want", "got", ""))
+
+BLOCKED = ("Source-of-truth: `Demo.BO.Ghost` would exist only in the IRIS namespace. "
+           "No file for it was found under this project, and the namespace is not "
+           "version-controlled, not reviewable, and does not survive the instance.")
+STORAGE = json.dumps({"error": "The class content includes an explicit Storage definition. "
+                               "Writing it via iris_doc would strip the Storage block."})
+# The real C shape, key-for-key from all 9 specimens in the corpus: it carries an
+# "error" key ALONGSIDE the compile markers. An invented fixture without "error"
+# passes for the wrong reason -- it falls through the final return instead of
+# exercising REACHED_IRIS_KEYS, and a mutant that deletes that check survives.
+COMPILE_FAIL = json.dumps({"compile_console": ["Compiling class Demo.BO.Ghost",
+                                               "Skipping class Demo.BO.Ghost"],
+                           "compile_errors": ["ERROR #5373: Class 'X' does not exist"],
+                           "compiled": False, "open_uri": "isfs://APP/Demo.BO.Ghost.cls",
+                           "storage_stripped": False,
+                           "error": "Compilation failed", "name": "Demo.BO.Ghost.cls"})
+OK_PUT = [{"type": "text", "text": json.dumps(
+    {"name": "Demo.BO.Ghost.cls", "open_uri": "isfs://APP/Demo.BO.Ghost.cls",
+     "storage_stripped": False, "success": True})}]
+
+for label, body, err, want in [
+        ("A  src_before_iris blocked the put", BLOCKED,      True,  "ALLOW"),
+        ("B  MCP refused it (storage guard)",  STORAGE,      True,  "ALLOW"),
+        ("C  stored, compile failed",          COMPILE_FAIL, True,  "BLOCK/orphan"),
+        ("D  put succeeded",                   OK_PUT,       False, "BLOCK/orphan")]:
+    t = transcript([rec_id(-300, "iris_doc", PUT_GHOST, "tu_1"),
+                    res(-299, "tu_1", body, err)])
+    clear(t)
+    check(label, want, stop(t, work))
 
 print("\n{} failure(s)".format(len(failures)))
 for f in failures:


### PR DESCRIPTION
Closes #157. `hooks/` and `scripts/` only — **no skill text touched**, frontmatter 20/20 byte-identical to `v1.8.14`.

### The filed fix would have broken it

The issue suggested *"count a put only when it succeeded … a compile failure arguably is not [a write] either."* Checked against **37 real put results** in a live transcript, that second half is wrong and expensively so:

| n | `is_error` | payload keys | verdict |
|---|---|---|---|
| 14 | false | `open_uri, storage_stripped` | D — written |
| 9 | false | `compile_console…compiled, open_uri, …` | D — written |
| **9** | **true** | `compile_console…compiled, open_uri, …, error` | **C — WRITTEN, compile skipped** |
| 4 | true | *prose* | A — never written |
| 1 | true | `error` | B — never written |

Case C stores the document and only skips the compile (`Skipping class X`). Excluding every `is_error` drops **9 of 37** real puts and switches CR-12 off for exactly the orphaned work it exists to catch — trading a false positive for a false negative, which is worse because nothing downstream flags it.

### What was implemented

Not *"did it error"* but **"is there positive evidence it never reached IRIS."** Payloads are parsed and matched on JSON **keys**, never substrings of prose — a substring gate here would guard a spelling rather than the outcome (CLAUDE.md, #151). Anything unrecognised, unparseable, or with no result still counts, so the change can only ever **remove** a false positive.

Puts are correlated to their `tool_result` by `tool_use_id`; put/delete replay in encounter order so a later delete still cancels an earlier put.

### The test that didn't work

Four cases added, one per shape. Both directions mutation-checked:

- **Mutant 1** — always count (pre-fix behaviour) → A and B go red. Killed.
- **Mutant 2** — drop the `REACHED_IRIS_KEYS` check → **survived.** My C fixture was invented from a truncated preview and omitted the `"error"` key, so it fell through the final `return` instead of exercising the check. All 9 real C payloads carry `error` alongside the compile markers. Fixture rebuilt from the real key set; mutant 2 now dies with C going `ALLOW`.

A test written from a guessed payload passes for the wrong reason, and only the mutant showed it.

### Verification

| check | result |
|---|---|
| `test_hooks` | exit 0, 0 failures — 9 pre-existing stop-gate cases unchanged |
| mutant 1 | A, B → MISMATCH — killed |
| mutant 2 | C → ALLOW — killed after fixture rebuild |
| restore | `diff` clean both times |
| `validate_skills` | exit 0, all 5 |
| `validate_examples` | exit 0 (tier 2 `--compile`: 34/34 clean, 34 deleted) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY