### PR TITLE
test: guard the compile-result parser with real captured payloads (#159)

### DIFF
--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -16,12 +16,14 @@ on:
       - 'BestPractices/**'
       - 'scripts/validate_examples.py'
       - 'scripts/examples_baseline.json'
+      - 'scripts/atelier_fixtures.json'
       - '.github/workflows/validate-examples.yml'
   pull_request:
     paths:
       - 'BestPractices/**'
       - 'scripts/validate_examples.py'
       - 'scripts/examples_baseline.json'
+      - 'scripts/atelier_fixtures.json'
       - '.github/workflows/validate-examples.yml'
   workflow_dispatch:
 

--- a/scripts/atelier_fixtures.json
+++ b/scripts/atelier_fixtures.json
@@ -1,0 +1,178 @@
+{
+  "_README": [
+    "Real Atelier /action/compile?flags=cuk responses, captured from live IRIS 2026.1 (ns APP)",
+    "on 2026-09-03 by staging deliberately broken classes. Consumed by tier 0 in",
+    "validate_examples.py, which checks the INSTRUMENT before the bank is measured with it.",
+    "",
+    "Every case says how it was obtained. 'captured' == verbatim from IRIS. 'derived' == a",
+    "captured payload with named fields removed to model a shape observed on another call",
+    "path. Nothing here is hand-written: an invented fixture is how a mutant survived in",
+    "test_hooks.py (#157), because it passed for a reason the real payload would not have."
+  ],
+  "dependency_5373": {
+    "_origin": "captured",
+    "_why": "The regression case. OLD parse_failures returned {} here and the gate printed 'compiled clean' for a class IRIS had skipped. params[0] is the ABSENT class (ZZProbe.DoesNotExistAnywhere), never in `staged`; the failing class is params[1] as 'ZZProbe.Bad:property:P'.",
+    "staged": [
+      "ZZProbe.Good",
+      "ZZProbe.Bad"
+    ],
+    "expect": [
+      "ZZProbe.Bad"
+    ],
+    "payload": {
+      "status": {
+        "errors": [
+          {
+            "error": "ERROR #5373: Class 'ZZProbe.DoesNotExistAnywhere', used by 'ZZProbe.Bad:property:P', does not exist",
+            "code": 5373,
+            "domain": "%ObjectErrors",
+            "id": "PredecessorClassDoesNotExist",
+            "params": [
+              "ZZProbe.DoesNotExistAnywhere",
+              "ZZProbe.Bad:property:P",
+              "",
+              "",
+              "",
+              "",
+              ""
+            ]
+          }
+        ]
+      },
+      "console": [
+        "",
+        "Compilation started on 09/03/2026 09:18:51 with qualifiers 'cuk'",
+        "ERROR #5373: Class 'ZZProbe.DoesNotExistAnywhere', used by 'ZZProbe.Bad:property:P', does not exist",
+        "Skipping class ZZProbe.Bad",
+        "Compiling class ZZProbe.Good",
+        "Compiling routine ZZProbe.Good.1",
+        "Detected 1 errors during compilation in 0.003s."
+      ]
+    }
+  },
+  "syntax_5475": {
+    "_origin": "captured",
+    "_why": "A DIFFERENT failure family, kept to prove the fix did not narrow to one shape. Stated honestly: the OLD code already handled this one, because the console line 'ERROR: ZZProbe.BadSyn.cls(Oops+3)' carries a .cls the old regex matched. It is a control, not a regression.",
+    "staged": [
+      "ZZProbe.Good",
+      "ZZProbe.BadSyn"
+    ],
+    "expect": [
+      "ZZProbe.BadSyn"
+    ],
+    "payload": {
+      "status": {
+        "errors": [
+          {
+            "error": "ERROR #5475: Error compiling routine: ZZProbe.BadSyn.1.  Errors:  ERROR: ZZProbe.BadSyn.cls(Oops+3) #1010: Missing right parenthesis : '}' : Offset:9 [Oops+2^ZZProbe.BadSyn.1]\r\n  > ERROR #5030: An error occurred while compiling class 'ZZProbe.BadSyn'",
+            "code": 5475,
+            "domain": "%ObjectErrors",
+            "id": "RoutineCompilationErrorWithInfo",
+            "params": [
+              "ZZProbe.BadSyn.1",
+              "ERROR: ZZProbe.BadSyn.cls(Oops+3) #1010: Missing right parenthesis : &#39;}&#39; : Offset:9 [Oops+2^ZZProbe.BadSyn.1]",
+              "",
+              "",
+              "",
+              "",
+              ""
+            ],
+            "errors": [
+              {
+                "error": "ERROR #5030: An error occurred while compiling class 'ZZProbe.BadSyn'",
+                "code": 5030,
+                "domain": "%ObjectErrors",
+                "id": "ErrorCompilingClass",
+                "params": [
+                  "ZZProbe.BadSyn"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "console": [
+        "",
+        "Compilation started on 09/03/2026 09:18:52 with qualifiers 'cuk'",
+        "Compiling 2 classes",
+        "Compiling class ZZProbe.BadSyn",
+        "Compiling class ZZProbe.Good",
+        "Compiling routine ZZProbe.Good.1",
+        "Compiling routine ZZProbe.BadSyn.1",
+        "ERROR: ZZProbe.BadSyn.cls(Oops+3) #1010: Missing right parenthesis : '}' : Offset:9 [Oops+2^ZZProbe.BadSyn.1]",
+        " TEXT:  Quit x }",
+        "Detected 1 errors during compilation in 0.004s."
+      ]
+    }
+  },
+  "all_valid": {
+    "_origin": "captured",
+    "_why": "Negative control. A fix that reddens everything is not a fix.",
+    "staged": [
+      "ZZProbe.Good",
+      "ZZProbe.Good2"
+    ],
+    "expect": [],
+    "payload": {
+      "status": {
+        "errors": []
+      },
+      "console": [
+        "",
+        "Compilation started on 09/03/2026 09:18:52 with qualifiers 'cuk'",
+        "Compiling 2 classes",
+        "Compiling class ZZProbe.Good2",
+        "Compiling class ZZProbe.Good",
+        "Compiling routine ZZProbe.Good2.1",
+        "Compiling routine ZZProbe.Good.1",
+        "Compilation finished successfully in 0.004s."
+      ]
+    }
+  },
+  "dependency_console_only": {
+    "_origin": "derived: captured dependency_5373 with status.errors emptied",
+    "_why": "The TESTSUITE session saw #5373 arrive with status.errors EMPTY through iist's client, while the raw Atelier path here populates it on both passes. Same error, different shape by call path -- so attribution must survive on console alone.",
+    "staged": [
+      "ZZProbe.Good",
+      "ZZProbe.Bad"
+    ],
+    "expect": [
+      "ZZProbe.Bad"
+    ],
+    "payload": {
+      "status": {
+        "errors": []
+      },
+      "console": [
+        "",
+        "Compilation started on 09/03/2026 09:18:51 with qualifiers 'cuk'",
+        "ERROR #5373: Class 'ZZProbe.DoesNotExistAnywhere', used by 'ZZProbe.Bad:property:P', does not exist",
+        "Skipping class ZZProbe.Bad",
+        "Compiling class ZZProbe.Good",
+        "Compiling routine ZZProbe.Good.1",
+        "Detected 1 errors during compilation in 0.003s."
+      ]
+    }
+  },
+  "unattributed": {
+    "_origin": "derived: captured console reduced to the lines that name no class",
+    "_why": "Guards the RECONCILIATION, which is the actual guarantee. Attribution is pattern-matching and can only cover shapes someone thought of; IRIS states how many errors it found, so a non-zero count with nothing attributed must fail loudly instead of returning {}.",
+    "staged": [
+      "ZZProbe.Good",
+      "ZZProbe.Bad"
+    ],
+    "expect": [
+      "<unattributed compile errors>"
+    ],
+    "payload": {
+      "status": {
+        "errors": []
+      },
+      "console": [
+        "",
+        "Compilation started on 09/03/2026 09:17:56 with qualifiers 'cuk'",
+        "Detected 1 errors during compilation in 0.003s."
+      ]
+    }
+  }
+}

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -128,6 +128,52 @@ def doc_headings() -> set[str]:
 # Tier 1 -- structural
 # --------------------------------------------------------------------------
 
+FIXTURES = Path(__file__).with_name("atelier_fixtures.json")
+
+
+def tier0() -> bool:
+    """Check the INSTRUMENT before measuring the bank with it.
+
+    Tier 2's verdict is only as good as `parse_failures`, and for one whole family of IRIS
+    errors that verdict was silently inverted: the gate printed "compiled clean" for a class
+    IRIS had refused (#159). A green tier 2 could not have revealed that -- it IS the thing
+    that was wrong -- so the parser gets its own red case, from real captured payloads.
+
+    No IRIS and no network: these are frozen responses, so this runs in CI on every PR while
+    the live `--compile` job runs only where an instance exists.
+
+    WHAT THESE FIXTURES DO AND DO NOT PIN DOWN, established by mutating the parser and watching
+    which case went red -- not by reading it:
+
+      dependency_5373           carried by the params scan OR the quoted-name extraction
+      dependency_console_only   carried by the quoted-name extraction OR `Skipping class`
+      unattributed              carried by the reconciliation ALONE
+
+    So the first two survive any SINGLE mechanism being removed and only die when two are
+    (mutants M1, M2, M4, M5, M7 all survived; M6 killed both). That redundancy is deliberate
+    -- the original defect was three paths failing on the same input at once -- but it means
+    a green here does NOT prove each mechanism is individually live. The reconciliation is the
+    exception and the one that matters: it is singly covered, and its mutant dies.
+    """
+    print("Tier 0 -- the compile-result parser\n")
+    rep = Report()
+    try:
+        cases = json.loads(read(FIXTURES))
+    except (OSError, ValueError) as exc:
+        print(f"  FAIL  fixtures unreadable: {exc}")
+        return False
+
+    for name, case in cases.items():
+        if name.startswith("_"):
+            continue
+        got = sorted(parse_failures(case["payload"], set(case["staged"])))
+        want = sorted(case["expect"])
+        rep.check(f"P-{name}", f"{name} -> {want or 'clean'}",
+                  [] if got == want else [f"expected {want}, got {got}"])
+
+    return rep.done("Tier 0")
+
+
 def tier1() -> bool:
     print("Tier 1 -- structural\n")
     r = Report()
@@ -484,7 +530,8 @@ def main() -> int:
     if args.preflight:
         return 0 if preflight() else 1
 
-    ok = tier1()
+    ok = tier0()
+    ok = tier1() and ok
     if args.compile:
         # A failed preflight means the environment is wrong, not the bank. Say which,
         # and do not stage 34 classes into an instance that cannot compile them.


### PR DESCRIPTION
Refs #159

#159 fixed `parse_failures`, but left it **unguarded**. A green tier 2 could never have caught
the original defect — the parser that decides tier 2's verdict *is* the thing that was wrong. So
the parser gets its own red case.

## Tier 0 — check the instrument before measuring with it

Five cases, from Atelier responses **captured off live IRIS 2026.1**, not hand-written. An
invented fixture is exactly how a mutant survived in `test_hooks.py`: it passed for a reason the
real payload would not have. Each case records how it was obtained (`captured` vs `derived`, with
the fields removed named).

| fixture | what it is |
|---|---|
| `dependency_5373` | **the regression.** Old code returned `{}` and printed "compiled clean" |
| `syntax_5475` | different error family — *stated honestly:* the old code already handled this one, it's a control, not a regression |
| `all_valid` | negative control; a fix that reddens everything is not a fix |
| `dependency_console_only` | `status.errors` emptied — the shape TESTSUITE saw through a different client, where our raw Atelier path populates it |
| `unattributed` | guards the reconciliation |

No IRIS, no network, so this runs on **every PR** rather than only where an instance exists.

## Mutation-tested, and the result was not what I'd have guessed

I broke the parser seven ways and watched which fixture went red:

| fixture | carried by | dies when |
|---|---|---|
| `dependency_5373` | params scan **or** quoted extraction | both removed (M6) |
| `dependency_console_only` | quoted extraction **or** `Skipping class` | both removed (M6) |
| `unattributed` | the reconciliation **alone** | M3 |

M1, M2, M4, M5 and M7 all **survived**. So the two attribution cases tolerate any single
mechanism being removed — the redundancy is deliberate, since the original defect was three paths
failing on one input simultaneously, but it means **a green here does not prove each mechanism is
individually live**. That limit is written into the docstring rather than left implicit. The
reconciliation is the exception: singly covered, mutant dies, and it's the one carrying the
guarantee.

## Also

Adds `scripts/atelier_fixtures.json` to the workflow path filters — without it, weakening a
fixture would not trigger the job that reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY