### PR TITLE
docs: record why the console-only fixture exists (#159)

### DIFF
--- a/scripts/atelier_fixtures.json
+++ b/scripts/atelier_fixtures.json
@@ -131,7 +131,7 @@
   },
   "dependency_console_only": {
     "_origin": "derived: captured dependency_5373 with status.errors emptied",
-    "_why": "The TESTSUITE session saw #5373 arrive with status.errors EMPTY through iist's client, while the raw Atelier path here populates it on both passes. Same error, different shape by call path -- so attribution must survive on console alone.",
+    "_why": "Models an environment where status.errors arrives EMPTY for a failure that this instance reports in BOTH fields -- so attribution must survive on console alone. NOT hypothetical: the TESTSUITE session measures, on their IRIS, that any document succeeding in the batch empties status.errors, while on ours (2026.1, ns APP, /api/atelier/v1, flags cuk) it is populated whenever anything failed -- verified across 1-doc all-fail, 2-doc all-fail, 2-doc mixed both orders, 3-doc mixed, and five qualifier strings. THREE explanations were proposed and all THREE were falsified by experiment: the #5373 error shape, the document-list arity, and whether the good document was merely up-to-date (everything is deleted cold here, and the console shows real 'Compiling class' lines). The cause is still unknown and is environmental, not client-side. That unresolved divergence is exactly WHY the parser reads both fields and then reconciles against IRIS's own count: this plugin ships to IRIS instances we cannot inspect, and a parser tuned to the one instance we can would be correct here and wrong there.",
     "staged": [
       "ZZProbe.Good",
       "ZZProbe.Bad"


### PR DESCRIPTION
Refs #159

The `dependency_console_only` fixture's rationale blamed "iist's client". That was wrong, and the
corrected version is a **stronger** argument for keeping the fixture.

Two IRIS instances genuinely disagree about when `status.errors` is populated:

- **Ours** (2026.1, ns APP, `/api/atelier/v1`, flags `cuk`) populates it whenever anything failed —
  verified across 1-doc all-fail, 2-doc all-fail, 2-doc mixed in **both** orders, 3-doc mixed, and
  five qualifier strings, with everything deleted cold so nothing is up-to-date.
- **Theirs** empties it as soon as any document in the batch succeeds.

Three explanations were proposed and **all three were falsified by experiment**: the `#5373` error
shape, the document-list arity, and whether the good document was merely up-to-date. The cause is
unknown and environmental, not client-side.

That unresolved divergence is precisely the argument for the design. The parser reads both fields
and then reconciles against IRIS's own error count because this plugin **ships to IRIS instances we
cannot inspect** — a parser tuned to the one instance we can reach would be correct here and wrong
there.

Comment-only; tier 0 still 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY