### PR TITLE
release: 1.8.16 — the example-bank gate could call a failed compile clean (#159)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.15"
+    "version": "1.8.16"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.15",
+      "version": "1.8.16",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 8 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Six commits since `v1.8.15`, all in the CI/dev validator and its fixtures. **No skill, agent or hook
content changed** — verified, not assumed: `git diff v1.8.15..HEAD -- skills/ agents/ hooks/` is empty.

## The defect (#159)

`scripts/validate_examples.py` guards the example bank on the rule that a broken example is worse
than none. It reported a class IRIS had **refused** as "compiled clean" — IRIS printed
`Skipping class ZZProbe.Bad` and `Detected 1 errors`, `parse_failures` returned `{}`, and tier 2
printed `compiled clean : 2 / 2`, exit 0.

Three causes: `params[0]` is the *absent* class not the failing one (which sits in `params[1]` as
`B:property:P`); the `\.cls` regex matches nothing because Atelier names classes bare and quoted;
and `Skipping class B` carries no `ERROR` token so the ERROR filter dropped exactly the line that
stated the outcome.

Found because TESTSUITE reported a same-**shaped** defect in `iist`'s client. Different mechanism,
identical outcome — a fix does not propagate across layers.

## The severity was worse than first filed

#159 called these "three causes any one of which would have been survivable". For the bank this gate
guards, that's false.

**A batch document that succeeds and compiles a table clears `status.errors` for the whole batch.**
Isolated by changing only the succeeding classes: `%RegisteredObject` → 1, `%Persistent` → 0. Six
other explanations were proposed across two sessions and **all six falsified**.

6 of 34 bank classes are persistent, so every real tier 2 batch returns `status.errors == []`.
Verified with real bank classes plus one broken class: status path empty, failure still attributed
from console alone. **The console path isn't a backup — it is the path**, and before the fix a
dependency failure had no route to the verdict at all. Independently reproduced by TESTSUITE: 44 of
their 46 fixture batches stage a table-compiling class.

## Tier 0

A green tier 2 could never have caught this — the parser producing tier 2's verdict *is* what was
broken. Six fixtures captured off live IRIS, each labelled `captured`/`derived`. Nothing
hand-written; an invented fixture is how a mutant survived in `test_hooks.py` at 1.8.15.

Mutation-tested: **5 of 7 mutants survived**, and that's in the docstring because it isn't what a
reader would guess. The attribution cases tolerate any single mechanism being removed; the
reconciliation is singly covered and its mutant dies.

## Verification

| check | result |
|---|---|
| `validate_skills` | exit 0, 5/5 |
| `test_hooks` | exit 0, 0 failures |
| `validate_examples --compile` | exit 0 — tier 0 6/6, tier 1 7/7, tier 2 **34/34 clean**, 34 deleted |
| namespace | 0 `Example.*`/`ZZ*` left in APP, against a **462-row `Ens.*` positive control** |
| content | `git diff v1.8.15..HEAD -- skills/ agents/ hooks/` **empty** |
| manifest | 20 skills / 9 hook commands / 4 agents — counted from disk, not copied |

## Known, deliberately not fixed here

The shipped description says "Ships 8 hooks" and enumerates `SessionStart + 2 PreToolUse + 5
PostToolUse`. `hooks.json` has **9** — the omitted one is the only **blocking Stop** hook. Not
corrected in a release commit because CLAUDE.md requires a before/after for any description edit
(#126, #127). Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY