### PR TITLE
fix: CR-12's remedy named the requirement but never the route (#169)

### DIFF
--- a/hooks/conformance_stop_gate.py
+++ b/hooks/conformance_stop_gate.py
@@ -488,23 +488,58 @@ def main():
     root = project_root(data)
     orphans = find_orphans(root, put)
 
+    # --- #169: the remedy has to be RECOVERABLE, not just mandatory ----------
+    #
+    # It used to say "write each class to disk with the same content that is in IRIS"
+    # -- naming the requirement and never the route. On a TRUE positive that invites a
+    # reconstruction from memory, which is not what compiled. On a FALSE positive the
+    # only way to comply is to invent source for a class that exists nowhere, which is
+    # strictly worse than the orphan CR-12 guards against. Both observed instances were
+    # an agent deliberately building a broken class to prove a check can fail, so the
+    # misfire selectively punished the discipline we are trying to instil.
+    #
+    # `iris_doc(mode=get)` answers both halves with one call: it returns the real source
+    # when the class is there, and it cannot return source when it is not. So the remedy
+    # is unfabricatable by construction -- an agent following it literally cannot produce
+    # a file for a class that never existed.
+    #
+    # This deliberately does NOT say "check first, and skip the gate if absent". Naming
+    # the escape route in a denial hands the agent its own bypass (upstream 1.2.7, fork
+    # #169/#170). The absence branch is phrased as an OUTCOME of doing the work, and it
+    # asks for the tool result rather than an assertion. Note also which way it moves the
+    # cheapest escape: today an agent that wants past this gate writes a plausible file,
+    # which is undetectable and pollutes the tree; now it has to run a tool and report
+    # what came back, which the transcript records. Adversarially this is a strict
+    # improvement, not a new hole.
+    #
+    # The criterion itself already had this right -- conformance-review/SKILL.md CR-12
+    # says "iris_doc(mode=get) the namespace-only classes and write them to src/". The
+    # fix never propagated to the enforcement message. Same defect, one layer down.
     if orphans:
         _trace("blocking_orphans", put=len(put), orphans=len(orphans))
         listed = "\n".join(
-            "  - {}   ->  write it to src/{}.cls".format(c, c.replace(".", "/"))
+            "  - {}   ->  iris_doc(mode=get, name=\"{}.cls\")  ->  src/{}.cls".format(
+                c, c, c.replace(".", "/"))
             for c in orphans[:15]
         )
         more = "\n  ... and {} more".format(len(orphans) - 15) if len(orphans) > 15 else ""
         latch_record(transcript, signature)
         block(
-            "CR-12 — {} of the {} class(es) this session wrote into IRIS exist ONLY in the "
+            "CR-12 \u2014 {} of the {} class(es) this session wrote into IRIS exist ONLY in the "
             "namespace:\n\n{}{}\n\n"
             "The namespace is not version-controlled, not reviewable, and does not survive the "
-            "instance, so this work is already lost — it just has not been noticed yet. Write "
-            "each class to disk with the same content that is in IRIS, then stop.\n\n"
+            "instance, so this work is already lost \u2014 it just has not been noticed yet.\n\n"
+            "RECOVER each one from IRIS \u2014 do not retype it from memory. What is in the "
+            "namespace is what actually compiled, and a reconstruction is not it:\n"
+            "  1. iris_doc(mode=get, name=\"<Class>.cls\", namespace=\"<NS>\")\n"
+            "  2. Write the returned source to src/<Pkg>/<Tipo>/<Name>.cls\n"
+            "then stop.\n\n"
+            "If mode=get answers that the class is not in the namespace, then it never reached "
+            "IRIS, there is nothing to save, and this demand was spurious. Report that tool "
+            "result and stop \u2014 do NOT create the file.\n\n"
             "(Measured: 16 runs finished with no .cls on disk at all and 12 of them scored as "
-            "passes, one at 96.45 — ground truth is read from the namespace, so saving nothing "
-            "still grades green.)".format(len(orphans), len(put), listed, more)
+            "passes, one at 96.45 \u2014 ground truth is read from the namespace, so saving "
+            "nothing still grades green.)".format(len(orphans), len(put), listed, more)
         )
 
     if not reviewed:

--- a/scripts/test_hooks.py
+++ b/scripts/test_hooks.py
@@ -231,6 +231,49 @@ for label, body, err, want in [
     clear(t)
     check(label, want, stop(t, work))
 
+# --------------------------------------------------------------------------------------
+print("\n#169  conformance_stop_gate — the CR-12 remedy must be RECOVERABLE")
+print("  {:<38}{:<16}{:<16}{}".format("case", "want", "got", ""))
+
+# The demand used to name the requirement ("write it to disk with the same content that
+# is in IRIS") and never the route, so the only way to comply for a class that does not
+# exist was to invent one. These assert the route is named, because the route is what
+# makes the instruction unfabricatable -- iris_doc(mode=get) cannot return source for a
+# class that was never there.
+#
+# COVERAGE, stated here because a clean run reads like more than it is: this checks the
+# SPELLING of the remedy, not that an agent follows it. It cannot see whether the file
+# an agent writes actually came from the namespace. What it does guarantee is that the
+# instruction can never silently drift back to the unfabricatable-free form (#169).
+
+
+def stop_reason(tpath, cwd, **extra):
+    p = subprocess.run([sys.executable, STOP],
+                       input=json.dumps(dict({"transcript_path": tpath, "cwd": cwd}, **extra)),
+                       capture_output=True, text=True)
+    if p.returncode != 0 or not p.stdout.strip():
+        return ""
+    return json.loads(p.stdout)["reason"]
+
+
+t = transcript([rec(-300, "iris_doc", PUT_GHOST)])
+clear(t)
+reason = stop_reason(t, work)
+
+# Two DISTINCT strings, because the route appears twice and one `in reason` test is
+# satisfied by either. A first draft asserted only "iris_doc(mode=get" and a mutant that
+# deleted the entire numbered-step block SURVIVED -- the per-class lines carried it.
+check("numbered step names the route", True, "1. iris_doc(mode=get" in reason)
+check("per-class line carries the route", True,
+      'iris_doc(mode=get, name="Demo.BO.Ghost.cls")' in reason)
+check("names the absent-class outcome", True, "not in the namespace" in reason)
+# A pin on the exact pre-#169 wording, not a general property: no grep can express "does
+# not tell the agent to write a file without saying where the content comes from".
+check("no longer says only `write it to`", False, "write it to src/" in reason)
+# Positive control: the reason is non-empty and really is the CR-12 branch, so the four
+# assertions above are reading text that exists rather than passing on an empty string.
+check("positive control — CR-12 branch fired", True, reason.startswith("CR-12"))
+
 print("\n{} failure(s)".format(len(failures)))
 for f in failures:
     print("  FAILED:", f)


### PR DESCRIPTION
Closes #169

## The defect

The Stop gate demanded *"write each class to disk with the same content that is in IRIS"* — naming the requirement and never the route. Two consequences:

- **On a true positive** it invites a reconstruction from memory. What is in the namespace is what compiled; a retype is not it.
- **On a false positive** the only way to comply is to invent source for a class that exists nowhere — strictly worse than the orphan CR-12 guards against. Both observed instances were an agent deliberately building a broken class to prove a check can fail, so the misfire selectively punished the discipline this plugin exists to push.

## The fix

The remedy now names `iris_doc(mode=get)`, which answers both halves in one call: it returns the real source when the class is there, and it **cannot** return source when it is not. The instruction is unfabricatable by construction.

That also dissolves the issue's objection to option 2 ("require proof of presence adds a round-trip to the common case"): the round-trip is not overhead here, it is *how the content is obtained*. The same call serves the true-positive path.

It deliberately does **not** say "check first and skip the gate if absent" — naming the escape route in a denial hands the agent its own bypass (upstream 1.2.7, fork #169/#170). The absence branch is phrased as an outcome of doing the work and asks for the tool result, not an assertion.

Note which way it moves the cheapest escape. Today an agent that wants past this gate writes a plausible file — undetectable, and it pollutes the tree. Now it has to run a tool and report what came back, which the transcript records. Adversarially this is a strict improvement, not a new hole.

## Where the fix already existed

`skills/conformance-review/SKILL.md` CR-12 already prescribed exactly this: *"`iris_doc(mode=get)` the namespace-only classes and write them to `src/`"*. It never propagated to the enforcement message. Same defect, one layer down.

## Verification

Five assertions added to `scripts/test_hooks.py`. A first draft asserted only `"iris_doc(mode=get"` and a mutant deleting the entire numbered-step block **survived**, because the per-class lines carried the same substring. Split into two distinct strings; three mutants now each die to exactly the assertion that should catch them:

| mutant | killed by |
|---|---|
| drop the numbered steps | `numbered step names the route` |
| revert the per-class line | `per-class line carries the route` + `no longer says only write it to` |
| drop the absence branch | `names the absent-class outcome` |

Gates: test_hooks 0 failures, validate_skills 6/6, validate_examples tier 0 6/6 · tier 1 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY