### PR TITLE
feat: every gate and guard message carries a stable [IIS-...] marker (#162)

### DIFF
--- a/hooks/conformance_prescan.py
+++ b/hooks/conformance_prescan.py
@@ -10,6 +10,10 @@ source of the verdict; this only decides whether a review is worth running.
 """
 import sys, json, os, re
 
+# Stable marker (#162): prepended, never woven into the prose, so a reword cannot
+# switch a corpus detector off. One grep for `[IIS-` finds every gate and guard.
+MARKER = "[IIS-PRESCAN] "
+
 
 def read_source(ti):
     """Best-effort: the .cls content from disk (post-write) or from the tool input."""
@@ -91,7 +95,8 @@ def main():
         "tests via the real iris_test tool, not a [SqlProc] self-report. Advisory."
     )
     print(json.dumps({"hookSpecificOutput": {
-        "hookEventName": "PostToolUse", "additionalContext": msg}}))
+        "hookEventName": "PostToolUse",
+        "additionalContext": MARKER + msg}}))
 
 
 if __name__ == "__main__":

--- a/hooks/conformance_stop_gate.py
+++ b/hooks/conformance_stop_gate.py
@@ -447,8 +447,14 @@ def strip_cls(name):
     return re.sub(r"\.cls$", "", name, flags=re.I)
 
 
-def block(reason):
-    print(json.dumps({"decision": "block", "reason": reason}))
+def block(rule, reason):
+    """Block with a stable leading marker (#162).
+
+    The corpus counts Stop-gate activity from `hook_blocking_error` records (62 across
+    49 runs), which says a block happened but not WHICH branch. The marker says which.
+    """
+    print(json.dumps({"decision": "block",
+                      "reason": "[IIS-STOP-" + rule + "] " + reason}))
     sys.exit(0)
 
 
@@ -525,6 +531,7 @@ def main():
         more = "\n  ... and {} more".format(len(orphans) - 15) if len(orphans) > 15 else ""
         latch_record(transcript, signature)
         block(
+            "CR12",
             "CR-12 \u2014 {} of the {} class(es) this session wrote into IRIS exist ONLY in the "
             "namespace:\n\n{}{}\n\n"
             "The namespace is not version-controlled, not reviewable, and does not survive the "
@@ -546,6 +553,7 @@ def main():
         _trace("blocking_no_review", put=len(put))
         latch_record(transcript, signature)
         block(
+            "REVIEW",
             "The conformance pass has not run. This session authored {} interop class(es) and "
             "every one is on disk, but nothing has checked them against the twelve criteria.\n\n"
             "Run it now:\n"

--- a/hooks/docker_detect.py
+++ b/hooks/docker_detect.py
@@ -7,6 +7,10 @@ note so the model retries over HTTP instead of giving up or re-trying with a con
 """
 import sys, json
 
+# Stable marker (#162): prepended, never woven into the prose, so a reword cannot
+# switch a corpus detector off. One grep for `[IIS-` finds every gate and guard.
+MARKER = "[IIS-DOCKER] "
+
 
 def payload(r):
     if isinstance(r, str):
@@ -39,7 +43,8 @@ def main():
             "need a container. Retry WITHOUT IRIS_CONTAINER; set it only if IRIS actually runs in Docker."
         )
         print(json.dumps({"hookSpecificOutput": {
-            "hookEventName": "PostToolUse", "additionalContext": msg}}))
+            "hookEventName": "PostToolUse",
+            "additionalContext": MARKER + msg}}))
 
 
 if __name__ == "__main__":

--- a/hooks/interop_bootstrap.py
+++ b/hooks/interop_bootstrap.py
@@ -8,6 +8,13 @@ being installed + instructed). This is the "make it available up front" half; th
 """
 import sys, json
 
+# Stable marker (#162): prepended, never woven into the prose. #115 detects "did any
+# hook run in this CLI at all" from this very message -- 318/318 claude runs carry it,
+# 0/676 codex and 0/289 opencode do -- so its text is load-bearing for a published
+# measurement and must stay greppable across rewordings.
+MARKER = "[IIS-BOOTSTRAP] "
+
+
 MSG = (
     "iris-interop-skills active. For ANY IRIS Interoperability work, BEFORE writing classes: load "
     "Skill(iris-interop-skills:interop) (router) + Skill(iris-interop-skills:component-map) + "
@@ -48,7 +55,8 @@ def main():
     except Exception:
         pass
     print(json.dumps({"hookSpecificOutput": {
-        "hookEventName": "SessionStart", "additionalContext": MSG}}))
+        "hookEventName": "SessionStart",
+        "additionalContext": MARKER + MSG}}))
 
 
 if __name__ == "__main__":

--- a/hooks/interop_conformance_gate.py
+++ b/hooks/interop_conformance_gate.py
@@ -98,11 +98,17 @@ NS_REQUIRED = {
 }
 
 
-def deny(reason):
+def deny(rule, reason):
+    """Emit a deny whose reason LEADS with a stable marker (#162).
+
+    The marker names which rule fired; the prose after it is free to change. Corpus
+    measurement keys on `[IIS-...]`, so improving a denial can no longer silently
+    switch a detector off. See MARKERS below for why this is prepend-only.
+    """
     print(json.dumps({"hookSpecificOutput": {
         "hookEventName": "PreToolUse",
         "permissionDecision": "deny",
-        "permissionDecisionReason": reason,
+        "permissionDecisionReason": "[IIS-CG-" + rule + "] " + reason,
     }}))
     sys.exit(0)
 
@@ -135,6 +141,7 @@ def main():
     tool = str(data.get("tool_name") or "").split("__")[-1]
     if tool in NS_REQUIRED and not ti.get("namespace"):
         deny(
+            "NS",
             "`" + tool + "` was called without `namespace`. The parameter is documented as optional, "
             "but it resolves Ens.Director / Ens_Config.* in the connection's default namespace — and "
             "when that one is not interop-enabled the call fails with an internal error that never "
@@ -151,6 +158,7 @@ def main():
         m = OBJ_BYPASS.search(code)
         if m:
             deny(
+                "EXEC",
                 "Loading/compiling classes through iris_execute (matched '%s') bypasses the MCP's "
                 "iris_doc/iris_compile path and this conformance gate. Write source with "
                 "iris_doc(mode=put) and compile with iris_compile — never $SYSTEM.OBJ.Load / "
@@ -165,6 +173,7 @@ def main():
             m = pattern.search(code)
             if m:
                 deny(
+                    "DICTW",
                     "Creating class source through iris_execute (matched '%s') bypasses the MCP's "
                     "iris_doc/iris_compile path, this gate, and the source-of-truth gate — so the "
                     "class lands in the namespace with no file on disk, which is not "
@@ -182,6 +191,7 @@ def main():
         m = DICT_GLOBAL.search(code)
         if m:
             deny(
+                "DICTR",
                 "`%s` is the undocumented internal class dictionary. Reading it is guessing at "
                 "IRIS internals, and its layout is not a contract — the supported APIs are.\n\n"
                 "Use, in order of preference:\n"
@@ -208,6 +218,7 @@ def main():
         for seg in type_segs:
             if seg in NONSTD:
                 deny(
+                    "NAME",
                     "Naming convention: '%s' uses the non-standard package segment '.%s.'. "
                     "iris-interop uses <Package>.<Tipo>.<Name> with Tipo in BS/BP/BO/DT/RUL/MSG — "
                     "rename '.%s.' to '.%s.' and retry. Load Skill(iris-interop-skills:component-map) "
@@ -231,6 +242,7 @@ def main():
                 is_adapter = cls_name.endswith("Adapter") or "Adapter" in type_segs
                 if not is_adapter and any(s in BS_BO_SEGS for s in type_segs):
                     deny(
+                        "ADAPTER",
                         "A Business Service/Operation must Extend Ens.BusinessService / Ens.BusinessOperation "
                         "and declare its adapter as `Parameter ADAPTER = \"%s\";` — not Extend the adapter "
                         "(%s) directly (that yields an empty, non-functional component). Fix the superclass + "

--- a/hooks/silent_execute_guard.py
+++ b/hooks/silent_execute_guard.py
@@ -8,6 +8,10 @@ Reads the PostToolUse JSON on stdin; defensive about field names across CC versi
 """
 import sys, json
 
+# Stable marker (#162): prepended, never woven into the prose, so a reword cannot
+# switch a corpus detector off. One grep for `[IIS-` finds every gate and guard.
+MARKER = "[IIS-SILENT] "
+
 
 def payload(r):
     if isinstance(r, str):
@@ -52,7 +56,8 @@ def main():
             "[SqlProc] and SELECT it, or verify the effect with iris_query."
         )
         print(json.dumps({"hookSpecificOutput": {
-            "hookEventName": "PostToolUse", "additionalContext": msg}}))
+            "hookEventName": "PostToolUse",
+            "additionalContext": MARKER + msg}}))
 
 
 if __name__ == "__main__":

--- a/hooks/src_before_iris.py
+++ b/hooks/src_before_iris.py
@@ -48,11 +48,12 @@ INTEROP_NAME = re.compile(r"\.(BS|BP|BO|DT|DTS|RUL|MSG|DAT|ADP|UTL|HL7)\.[^.]+$"
 SKIP_DIRS = {".git", "node_modules", "__pycache__", ".venv", "venv", ".idea", ".vscode"}
 
 
-def deny(reason):
+def deny(rule, reason):
+    """Deny with a stable leading marker (#162) -- see interop_conformance_gate.deny."""
     print(json.dumps({"hookSpecificOutput": {
         "hookEventName": "PreToolUse",
         "permissionDecision": "deny",
-        "permissionDecisionReason": reason,
+        "permissionDecisionReason": "[IIS-SRC-" + rule + "] " + reason,
     }}))
     sys.exit(0)
 
@@ -131,6 +132,7 @@ def main():
 
     rel = "src/" + cls.replace(".", "/") + ".cls"
     deny(
+        "DISK",
         "Source-of-truth: `" + cls + "` would exist only in the IRIS namespace. No file for it "
         "was found under this project, and the namespace is not version-controlled, not "
         "reviewable, and does not survive the instance.\n\n"

--- a/hooks/tdd_enforcement.py
+++ b/hooks/tdd_enforcement.py
@@ -23,6 +23,10 @@ fired zero times, then a corpus where every fire was a false positive):
 """
 import sys, json, os, re, glob
 
+# Stable marker (#162): prepended, never woven into the prose, so a reword cannot
+# switch a corpus detector off. One grep for `[IIS-` finds every gate and guard.
+MARKER = "[IIS-TDD-NOTEST] "
+
 # Type segment delimited by a dot OR a path separator on BOTH sides: matches `Pkg.BO.Name`
 # and `src/Pkg/BO/Name.cls`, never a substring of a directory name. `DTL`/`Rule` are kept
 # as segment-anchored aliases for projects that don't use the Tipo abbreviations.
@@ -96,7 +100,8 @@ def main():
         "green on a test that was red before."
     )
     print(json.dumps({"hookSpecificOutput": {
-        "hookEventName": "PostToolUse", "additionalContext": msg}}))
+        "hookEventName": "PostToolUse",
+        "additionalContext": MARKER + msg}}))
 
 
 if __name__ == "__main__":

--- a/hooks/tdd_first_green.py
+++ b/hooks/tdd_first_green.py
@@ -15,6 +15,10 @@ in the project, not first in the session. Advisory only; never blocks.
 """
 import sys, json, os, re, hashlib
 
+# Stable marker (#162): prepended, never woven into the prose, so a reword cannot
+# switch a corpus detector off. One grep for `[IIS-` finds every gate and guard.
+MARKER = "[IIS-TDD-GREEN] "
+
 LEDGER = ".claude/.iris-interop-tdd-seen"
 
 
@@ -90,7 +94,8 @@ def main():
         "See iris-interop-skills:tdd, 'How much test is enough'."
     )
     print(json.dumps({"hookSpecificOutput": {
-        "hookEventName": "PostToolUse", "additionalContext": msg}}))
+        "hookEventName": "PostToolUse",
+        "additionalContext": MARKER + msg}}))
 
 
 if __name__ == "__main__":

--- a/scripts/test_hooks.py
+++ b/scripts/test_hooks.py
@@ -11,7 +11,7 @@ controls matter more than the negative ones. Run from the repo root:
 
     python3 scripts/test_hooks.py
 """
-import json, os, subprocess, sys, tempfile, time
+import io, json, os, subprocess, sys, tempfile, time
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 GATE = os.path.join(ROOT, "hooks", "interop_conformance_gate.py")
@@ -272,7 +272,120 @@ check("names the absent-class outcome", True, "not in the namespace" in reason)
 check("no longer says only `write it to`", False, "write it to src/" in reason)
 # Positive control: the reason is non-empty and really is the CR-12 branch, so the four
 # assertions above are reading text that exists rather than passing on an empty string.
-check("positive control — CR-12 branch fired", True, reason.startswith("CR-12"))
+check("positive control — CR-12 branch fired", True,
+      reason.startswith("[IIS-STOP-CR12] CR-12"))
+
+# --------------------------------------------------------------------------------------
+print("\n#162  every gate and guard message carries a stable marker")
+print("  {:<38}{:<16}{:<16}{}".format("case", "want", "got", ""))
+
+# A corpus can only count gate activity by grepping the message text, so every reword has
+# silently degraded a measurement. The concrete cost, measured by the testsuite session:
+# their parser was blind from plugin 1.6.0 through 1.8.8 -- EIGHT releases -- because their
+# pattern said "an interop component" and the hook says "the interop component". One word,
+# and the failure reads as "the gate did not fire", which is silence, which nothing notices.
+#
+# So markers are PREPENDED and the prose is left byte-identical. That is the whole design:
+# a prefix cannot break an unanchored downstream search, so the marker can land in one
+# release and detectors can migrate to it in their own time, with no window where the old
+# pattern has stopped matching and the new one has not started.
+#
+# COVERAGE: this checks that a marker is EMITTED and is unique. It cannot check that the
+# marker means what it says, and it is not evidence about how often any rule fires.
+import ast as _ast, glob as _glob, re as _re
+
+_markers, _unmarked = {}, []
+for _path in sorted(_glob.glob(os.path.join(ROOT, "hooks", "*.py"))):
+    _fn = os.path.basename(_path)
+    _src = io.open(_path, encoding="utf-8").read()
+    _tree = _ast.parse(_src)
+    # The prefix is read out of the module's own deny()/block() body rather than hardcoded
+    # here, so uniqueness is checked on the marker that is actually EMITTED. Two hooks may
+    # legitimately share a rule name ("NAME") under different prefixes; they may not share
+    # a full marker, because a corpus cannot tell those apart.
+    _prefix = ""
+    for _node in _tree.body:
+        if isinstance(_node, _ast.FunctionDef) and _node.name in ("deny", "block"):
+            for _sub in _ast.walk(_node):
+                if isinstance(_sub, _ast.Constant) and isinstance(_sub.value, str) \
+                        and _sub.value.startswith("[IIS-"):
+                    _prefix = _sub.value
+    # (a) deny()/block() call sites must pass a rule literal as their first argument.
+    for _node in _ast.walk(_tree):
+        if not isinstance(_node, _ast.Call) or not isinstance(_node.func, _ast.Name):
+            continue
+        if _node.func.id not in ("deny", "block") or not _node.args:
+            continue
+        _first = _node.args[0]
+        if isinstance(_first, _ast.Constant) and isinstance(_first.value, str) \
+                and _re.fullmatch(r"[A-Z0-9]+(-[A-Z0-9]+)*", _first.value):
+            _markers.setdefault(_prefix + _first.value + "]", []).append(
+                "%s:%d" % (_fn, _node.lineno))
+        else:
+            _unmarked.append("%s:%d  %s()" % (_fn, _node.lineno, _node.func.id))
+    # (b) a PostToolUse guard carries its marker as a module constant instead.
+    for _node in _tree.body:
+        if isinstance(_node, _ast.Assign) and any(
+                isinstance(t, _ast.Name) and t.id == "MARKER" for t in _node.targets):
+            _lit = getattr(_node.value, "value", None)
+            _markers.setdefault(str(_lit), []).append("%s:%d" % (_fn, _node.lineno))
+    if "additionalContext" in _src and "MARKER" not in _src:
+        _unmarked.append("%s  emits additionalContext with no MARKER" % _fn)
+
+_dupes = ["%s at %s" % (k, ", ".join(v)) for k, v in sorted(_markers.items()) if len(v) > 1]
+check("every deny/block/guard site is marked", 0, len(_unmarked))
+check("no marker is used twice", 0, len(_dupes))
+for _bad in _unmarked + _dupes:
+    print("          - {}".format(_bad))
+# A clean list is not evidence until it is non-empty: nine sites exist, and an AST walk that
+# silently matched nothing would also report zero unmarked. This is the control.
+check("positive control — sites were actually found", True, len(_markers) >= 15)
+
+print("\n  marker inventory (enumerated, not filtered — see #131):")
+for _m, _where in sorted(_markers.items()):
+    print("    {:<28} {}".format(_m, ", ".join(_where)))
+
+# --------------------------------------------------------------------------------------
+# Source-level checks prove the literal is PRESENT; they do not prove it reaches the
+# output. These two run the gate for real and read the emitted reason, which is the only
+# thing a corpus ever sees.
+def gate_reason(payload):
+    p = subprocess.run([sys.executable, GATE], input=json.dumps(payload),
+                       capture_output=True, text=True)
+    if p.returncode != 0 or not p.stdout.strip():
+        return ""
+    return json.loads(p.stdout)["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+_emitted = gate_reason(
+    doc("Demo.BS.FileIn.cls", "Class Demo.BS.FileIn Extends EnsLib.File.InboundAdapter\n{\n}"))
+check("marker reaches the emitted reason", True, _emitted.startswith("[IIS-CG-ADAPTER] "))
+check("and the keyed prose survives it", True,
+      bool(_re.search(r"must Extend Ens\.BusinessService", _emitted)))
+
+print("\n#162  the prose downstream detectors key on is UNCHANGED")
+print("  {:<38}{:<16}{:<16}{}".format("case", "want", "got", ""))
+
+# Pinned from iris-interop-skills-test `src/iist/grading/taxonomy.py` GATE_PATTERN_STRINGS.
+# That repo greps these literals out of hook output. They are recorded HERE so that a future
+# reword sees the cost before making it, rather than discovering it as eight releases of
+# silence. This is a COUPLING, not a style rule: if one of these must change, tell that
+# session first and let the marker-keyed detector land ahead of the change.
+for _label, _pat, _fn in [
+        ("naming-convention",         r"Naming convention:",                          "interop_conformance_gate.py"),
+        ("adapter-extended-directly", r"must Extend Ens\.BusinessService",            "interop_conformance_gate.py"),
+        ("load-via-iris_execute",     r"Loading/compiling classes through iris_execute", "interop_conformance_gate.py"),
+        ("tdd-without-test",          r"TDD: you just wrote the interop component",   "tdd_enforcement.py"),
+        ("source-of-truth",           r"Source-of-truth:",                            "src_before_iris.py")]:
+    _src = io.open(os.path.join(ROOT, "hooks", _fn), encoding="utf-8").read()
+    check(_label, True, bool(_re.search(_pat, _src)))
+# Negative control: their shipped pattern for the TDD rule said "an interop component" and
+# never matched any release from 1.6.0 to 1.8.8. Pinning the wrong string is the failure this
+# section exists to prevent, so assert the wrong one does NOT match.
+check("negative control — \"an\" must not match", False,
+      bool(_re.search(r"TDD: you just wrote an interop component",
+                      io.open(os.path.join(ROOT, "hooks", "tdd_enforcement.py"),
+                              encoding="utf-8").read())))
 
 print("\n{} failure(s)".format(len(failures)))
 for f in failures:


### PR DESCRIPTION
Closes #162

## Why

A corpus can only count gate activity by grepping message text, so every reword has silently degraded a measurement. The cost is measured, not hypothetical — from the testsuite session:

> Their gate parser was blind from plugin **1.6.0 through 1.8.8 — eight releases** — because its pattern said `"an interop component"` and the hook says `"the interop component"`. One word. It read as *"the gate did not fire"*, which is silence, which nothing notices.

## The markers

| marker | site |
|---|---|
| `[IIS-BOOTSTRAP]` | SessionStart conventions text |
| `[IIS-CG-NS]` `[IIS-CG-EXEC]` `[IIS-CG-DICTW]` `[IIS-CG-DICTR]` `[IIS-CG-NAME]` `[IIS-CG-ADAPTER]` | the six conformance-gate denials |
| `[IIS-SRC-DISK]` | source-of-truth denial |
| `[IIS-STOP-CR12]` `[IIS-STOP-REVIEW]` | the two Stop-gate blocks |
| `[IIS-PRESCAN]` `[IIS-SILENT]` `[IIS-DOCKER]` `[IIS-TDD-NOTEST]` `[IIS-TDD-GREEN]` | the five PostToolUse guards |

One search for `\[IIS-` finds all plugin gate and guard activity; the suffix identifies which rule.

## Scope is wider than the issue title, deliberately

#162 says "deny reasons". But the eight-release blindness above was on an **advisory** guard, and #115's *"did any hook run in this CLI at all"* finding (318/318 claude, 0/676 codex, 0/289 opencode) is read off the **SessionStart** text. Same fragility, same fix — leaving them out would have left the two messages with published measurements attached to them unmarked.

## Markers are prepended and no prose byte changes

That is the whole design. A prefix cannot break an unanchored downstream search, so this lands in one release and detectors migrate in their own time. There is no window where the old pattern has stopped matching and the new one has not started — which is the window a simultaneous reword would have opened, and which the testsuite session specifically asked to avoid. It goes further than they asked: no fallback alternation is needed if nothing is reworded.

The marker names the **rule**, never the remediation. Naming the way past a gate in the gate's own text is the escalation recipe behind upstream 1.2.7 / fork #169–#170; a rule id is not one.

## Enforcement, so this cannot rot the way the prose did

- **AST walk** of `hooks/*.py` asserts every `deny()`/`block()` site passes a rule literal and every `additionalContext` emitter carries a `MARKER`. It found `interop_bootstrap.py` on its first run, which I had missed.
- Full markers are **derived from each module's own prefix**, not hardcoded in the test, so uniqueness is checked on the marker actually *emitted* rather than the rule name.
- The inventory is **printed every run** — enumerate, never filter (#131).
- **Two end-to-end checks** run the gate and read the emitted reason, because a literal present in source is not a literal that reaches the output.
- **The five phrases `iris-interop-skills-test` keys on are pinned here**, with the `"an"` variant pinned as a *negative* control — so the exact drift that caused eight releases of silence now fails a test instead of passing quietly.

## Mutation-verified

| mutant | killed by |
|---|---|
| drop a rule literal from a deny site | `every deny/block/guard site is marked` |
| duplicate a marker across two hooks | `no marker is used twice` |
| reword `Naming convention:` | `naming-convention` |
| the one-word `the` → `an` drift | `tdd-without-test` **and** the negative control |

Gates: test_hooks 0 failures, validate_skills 6/6, validate_examples tier 0 6/6 · tier 1 7/7.

**Coverage note** (per the #151 convention): this checks that a marker is *emitted* and is *unique*. It cannot check that a marker means what it says, and a clean run is not evidence about how often any rule fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY