### PR TITLE
release: 1.8.17 — the enforcement layer becomes measurable (#162, #167, #169)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "IRIS For Health Interoperability skills for Claude Code.",
-    "version": "1.8.16"
+    "version": "1.8.17"
   },
   "plugins": [
     {
       "name": "iris-interop-skills",
       "source": "./",
       "description": "20 skills for building IRIS For Health Interoperability productions with Claude — including a task→component map and a post-build conformance review. Start at the iris-interop router. Requires an IRIS MCP server (iris-agentic-dev or iris-interop-dev). Ships 9 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards + 1 blocking Stop gate that refuses to finish until the conformance pass has run) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
-      "version": "1.8.16",
+      "version": "1.8.17",
       "category": "healthcare",
       "keywords": [
         "iris",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "iris-interop-skills",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "description": "20 skills that steer Claude when building IRIS For Health Interoperability productions — a task→component map, messages, BS/BP/BO, BPL, DTL transformations, HL7 v2 schemas, SOAP/REST, FHIR, DICOM, lookup tables, alerting, security, production lifecycle, message search/debug, a TDD-first workflow, and a post-build conformance review. Start at the iris-interop router. Assumes an IRIS MCP server (iris-agentic-dev or iris-interop-dev) is available. Ships 9 hooks (SessionStart conventions bootstrap + 2 PreToolUse gates that block non-conformant writes, class loads/compiles smuggled through iris_execute, and namespace-only classes missing from src/ + 5 PostToolUse guards + 1 blocking Stop gate that refuses to finish until the conformance pass has run) + 4 agents (interop-builder, deploy-smoke-test, introspect-dont-guess, conformance-reviewer).",
   "author": {
     "name": "Pierre-Yves Duquesnoy",


### PR DESCRIPTION
Three changes since 1.8.16, all in `hooks/` and the gates that check them.

**No skill, agent or example content changed** — verified, not assumed: `git diff v1.8.16..HEAD -- BestPractices/ skills/ agents/` is empty, and the same command over `v1.7.0..v1.8.0` returns six files, so the empty result is a real zero and not a broken invocation.

## #167 (PR #168) — both shipped descriptions said "8 hooks"

They enumerated 1 + 2 + 5 and silently omitted the `conformance-stop-gate` — the only **blocking Stop hook** in the package, and the single most surprising thing installing this plugin does. Hand-maintained, so it went stale the release the Stop gate was added and nothing noticed for nine versions.

Now 9, and `validate_skills` **S6 derives** the number from `hooks.json` rather than trusting it: reword freely, the count cannot drift. S6 also fails if *no* shipped description states a count, because a vanished claim is a silent pass, not a clean one.

## #169 (PR #170) — CR-12's remedy named the requirement but never the route

The Stop gate demanded *"write each class to disk with the same content that is in IRIS"* without saying how to obtain that content.

- **True positive:** invites a reconstruction from memory. What is in the namespace is what compiled; a retype is not it.
- **False positive:** the only way to comply is to invent source for a class that exists nowhere — strictly worse than the orphan CR-12 guards against. Both observed instances were an agent deliberately building a broken class to prove a check can fail, so the misfire selectively punished the discipline this plugin exists to push.

The remedy now names `iris_doc(mode=get)`, which returns the real source when the class is there and **cannot** return source when it is not — unfabricatable by construction. It deliberately does *not* say "check first and skip the gate if absent": naming the escape route in a denial hands the agent its own bypass. `conformance-review` CR-12 already prescribed exactly this; the fix had never reached the enforcement message.

## #162 (PR #171) — every gate and guard message carries a stable `[IIS-...]` marker

A corpus can only count gate activity by grepping message text, so every reword has silently degraded a measurement. Measured cost, from the testsuite session: **their parser was blind from 1.6.0 through 1.8.8 — eight releases — because their pattern said `"an interop component"` and the hook says `"the interop component"`.** One word, and the failure reads as *"the gate did not fire"*, which is silence.

Fifteen markers: `[IIS-BOOTSTRAP]`, six `[IIS-CG-*]` denials, `[IIS-SRC-DISK]`, `[IIS-STOP-CR12]` / `[IIS-STOP-REVIEW]`, and five guards. One search for `\[IIS-` finds all of it; the suffix says which rule.

**Markers are prepended and no prose byte changes.** A prefix cannot break an unanchored downstream search, so this lands in one release and consumers migrate whenever — no window where the old pattern has stopped matching and the new one has not started.

## Upgrade note

The only prose that changed anywhere is the Stop gate's CR-12 block text (#169). It still begins `CR-12` (now after `[IIS-STOP-CR12] `), so anything keyed on that is unaffected; the string `write it to src/` is gone.

## Verification

`test_hooks` 0 failures, `validate_skills` 6/6, `validate_examples` tier 0 6/6 + tier 1 7/7. Seven mutants across #162 and #169 each die to exactly the assertion that should catch them, including the one-word `the`→`an` drift, now pinned as a **negative** control.

**Tier 2 (`--compile` against live IRIS) did not run and is not claimed.** The dev instance has been up four days unhealthy: ns `APP` has no `Ens.Director`, and even `SELECT 1` fails with `<CLASS DOES NOT EXIST> %SYS.SQLStatementCache`. The preflight refused rather than reporting a bank failure — which is what it is for. The bank is byte-identical to 1.8.16, which was verified 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XnMqRrYytWBVdawUEaP6GY